### PR TITLE
fix box zoom in julia 1

### DIFF
--- a/src/camera/camera2d.jl
+++ b/src/camera/camera2d.jl
@@ -140,7 +140,7 @@ end
 
 function absrect(rect)
     xy, wh = minimum(rect), widths(rect)
-    xy = ntuple(Val{2}) do i
+    xy = ntuple(Val(2)) do i
         wh[i] < 0 ? xy[i] + wh[i] : xy[i]
     end
     FRect(Vec2f0(xy), Vec2f0(abs.(wh)))


### PR DESCRIPTION
The new `ntuple` syntax is `ntuple(Val(n), f)`