### PR TITLE
Axis texts in black, no additional axes through origin in 2D

### DIFF
--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -51,7 +51,7 @@ using .Formatters
             linewidth = 1.0,
             linecolor = :black,
             linestyle = nothing,
-            axis_position = :origin,
+            axis_position = nothing,
             axis_arrow = false,
             arrow_size = 2.5,
             frames = ((false, false), (false, false)),
@@ -249,7 +249,7 @@ function draw_frame(
         for i = 1:N
             start = unit(Point{N, Float32}, i) * Float32(mini[i])
             to = unit(Point{N, Float32}, i) * Float32(maxi[i])
-            if false#axis_arrow
+            if false #axis_arrow
                 arrows(
                     scene, [start, to],
                     linewidth = linewidth, linecolor = linecolor, linestyle = linestyle,
@@ -402,7 +402,7 @@ function draw_axis(
     return
 end
 
-# for axis, we don't want to have plot!(scene, args called on it, so we need to overload it directly)
+# for axis, we don't want to have plot!(scene, args) called on it, so we need to overload it directly
 function plot!(scene::SceneLike, ::Type{<: Axis2D}, attributes::Attributes, args...)
     # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
     cplot, non_plot_kwargs = Axis2D(scene, attributes, args)

--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -19,7 +19,6 @@ end
 using .Formatters
 
 @recipe(Axis2D) do scene
-    darktext = RGBAf0(0.0, 0.0, 0.0, 0.4)
     Theme(
         ticks = Theme(
 
@@ -35,7 +34,7 @@ using .Formatters
             linecolor = ((:black, 0.4), (:black, 0.4)),
             linestyle = (nothing, nothing),
 
-            textcolor = (darktext, darktext),
+            textcolor = (:black, :black),
             textsize = (5, 5),
             rotation = (0.0, 0.0),
             align = ((:center, :top), (:right, :center)),
@@ -88,7 +87,6 @@ end
     axisnames_align3d = tickalign3d
     tick_color = RGBAf0(0.5, 0.5, 0.5, 0.6)
     grid_color = RGBAf0(0.5, 0.5, 0.5, 0.4)
-    darktext = RGB(0.4, 0.4, 0.4)
     grid_thickness = 1
     gridthickness = ntuple(x-> 1f0, Val(3))
     tsize = 5 # in percent
@@ -100,7 +98,7 @@ end
 
         names = Theme(
             axisnames = ("x", "y", "z"),
-            textcolor = (darktext, darktext, darktext),
+            textcolor = (:black, :black, :black),
             rotation = axisnames_rotation3d,
             textsize = (6.0, 6.0, 6.0),
             align = axisnames_align3d,
@@ -125,7 +123,7 @@ end
         frame = Theme(
             linecolor = (grid_color, grid_color, grid_color),
             linewidth = (grid_thickness, grid_thickness, grid_thickness),
-            axiscolor = (darktext, darktext, darktext),
+            axiscolor = (:black, :black, :black),
         )
     )
 end


### PR DESCRIPTION
cc @mkborregaard  

Make axis texts black. 
Currently, axes within the picture through the origin aren't well supported in 2D plots, so setting `axis_position = nothing` makes most sense at the moment. 
Adresses https://github.com/JuliaPlots/Makie.jl/issues/129
