### PR TITLE
add scatterlines

### DIFF
--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -495,3 +495,13 @@ convert_arguments(P::Type{<:AbstractPlot}, f::Function) = convert_arguments(P, f
 convert_arguments(P::Type{<:AbstractPlot}, f::Function, r) = convert_arguments(P, r, f.(r))
 convert_arguments(P::Type{<:AbstractPlot}, f::Function, min, max) =
     convert_arguments(P, f, PlotUtils.adapted_grid(f, (min, max)))
+
+@recipe(ScatterLines) do scene
+    Theme()
+end
+
+function plot!(scene::SceneLike, ::Type{<:ScatterLines}, attributes::Attributes, p...)
+    plot!(scene, Lines, attributes, p...)
+    plot!(scene, Scatter, attributes, p...)
+    scene
+end


### PR DESCRIPTION
This is the equivalent of  `Plots.scatterpath` to draw a scatter plot where the points are connected by a line. It's useful when drawing some function that is only defined when `x` is an integer, for example:

```julia
julia> f(x) = pdf(Poisson(), x)
f (generic function with 1 method)

julia> s = scatterlines(f, 0:6)
```
![test](https://user-images.githubusercontent.com/6333339/45026917-bd467000-b037-11e8-9333-1a5e3740e33b.png)
