### PR TITLE
Fix Orthographic projection

### DIFF
--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -138,11 +138,8 @@ function translate_cam!(scene::Scene, cam::Camera3D, _translation::VecTypes)
     zoom, x, y = translation
     zoom *= 0.1f0 * dir_len
 
-    if projectiontype != Perspective
-        x, y = GLAbstraction.to_worldspace(Vec2f0(x, y), scene.projectionview[], cam_res)
-    else
-        x, y = (Vec2f0(x, y) ./ cam_res) .* dir_len
-    end
+    x, y = (Vec2f0(x, y) ./ cam_res) .* dir_len
+
     dir_norm = normalize(dir)
     right = normalize(cross(dir_norm, upvector))
     zoom_trans = dir_norm * zoom


### PR DESCRIPTION
In relation to https://github.com/JuliaPlots/Makie.jl/issues/156

The issue seems to be the call to `GLAbstraction.to_worldspace`. Rotation, translation, zoom and resizing all work fine without it (and an orthographic camera). Though the initial zoom level is very zoomed in.