### PR TITLE
implement `frames` axis argument

### DIFF
--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -245,7 +245,7 @@ end
 function draw_frame(
         linebuffer, limits::NTuple{N, Any},
         linewidth, linecolor, linestyle,
-        axis_position, axis_arrow, arrow_size
+        axis_position, axis_arrow, arrow_size, frames
     ) where N
 
     mini = minimum.(limits)
@@ -279,12 +279,14 @@ function draw_frame(
         if !(from == origin && axis_position == :origin)
             for otherside in 1:2
                 for dim in 1:N
-                    p = ntuple(i-> i == dim ? limits[i][otherside] : limits[i][side], Val(N))
-                    to = Point{N, Float32}(p)
-                    append!(
-                        linebuffer, [from, to],
-                        linewidth = linewidth, color = linecolor#, linestyle = linestyle,
-                    )
+                    if !frames[dim][otherside]
+                        p = ntuple(i-> i == dim ? limits[i][otherside] : limits[i][side], Val(N))
+                        to = Point{N, Float32}(p)
+                        append!(
+                            linebuffer, [from, to],
+                            linewidth = linewidth, color = linecolor#, linestyle = linestyle,
+                        )
+                    end
                 end
             end
         end
@@ -357,7 +359,7 @@ function draw_axis2d(
 
         # frame attributes
         f_linewidth, f_linecolor, f_linestyle,
-        f_axis_position, f_axis_arrow, f_arrow_size,
+        f_axis_position, f_axis_arrow, f_arrow_size, f_frames,
 
         # title / axis name attributes
         ti_labels,
@@ -397,7 +399,8 @@ function draw_axis2d(
     draw_frame(
         linebuffer, limits,
         f_linewidth, f_linecolor, f_linestyle,
-        f_axis_position, f_axis_arrow, f_arrow_size
+        f_axis_position, f_axis_arrow, f_arrow_size,
+        f_frames,
     )
 
     draw_titles(
@@ -415,7 +418,7 @@ function plot!(scene::SceneLike, ::Type{<: Axis2D}, attributes::Attributes, args
     # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
     cplot, non_plot_kwargs = Axis2D(scene, attributes, args)
     g_keys = (:linewidth, :linecolor, :linestyle)
-    f_keys = (:linewidth, :linecolor, :linestyle, :axis_position, :axis_arrow, :arrow_size)
+    f_keys = (:linewidth, :linecolor, :linestyle, :axis_position, :axis_arrow, :arrow_size, :frames)
     t_keys = (
         :linewidth, :linecolor, :linestyle,
         :textcolor, :textsize, :rotation, :align, :font,

--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -279,7 +279,7 @@ function draw_frame(
         if !(from == origin && axis_position == :origin)
             for otherside in 1:2
                 for dim in 1:N
-                    if !frames[dim][otherside]
+                    if frames[N-dim+1][3-otherside]
                         p = ntuple(i-> i == dim ? limits[i][otherside] : limits[i][side], Val(N))
                         to = Point{N, Float32}(p)
                         append!(

--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -272,6 +272,7 @@ function draw_frame(
         end
     end
     limit_widths = maxi .- mini
+    frames = convert_attribute(frames, key"frames"())
     for side in 1:2
         from = Point{N, Float32}(getindex.(limits, side))
         # if axis is drawn at origin, and we draw frame from origin,

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -431,6 +431,13 @@ function convert_attribute(ls::Symbol, ::key"linestyle")
     end
 end
 
+function convert_attribute(f::Symbol, ::key"frames")
+    f == :box && return ((true, true), (true, true))
+    f == :semi && return ((true, false), (true, false))
+    f == :none && return ((false, false), (false, false))
+    throw(MethodError("$(string(f)) is not a valid framestyle. Options are `:box`, `:semi` and `:none`"))
+end
+convert_attribute(f::Tuple{Tuple{Bool,Bool},Tuple{Bool,Bool}}, ::key"frames") = f
 
 convert_attribute(c::Tuple{<: Number, <: Number}, ::key"position") = Point2f0(c[1], c[2])
 convert_attribute(c::Tuple{<: Number, <: Number, <: Number}, ::key"position") = Point3f0(c)


### PR DESCRIPTION
Allows
```julia
using AbstractPlotting, Makie
newtheme = Theme(
    axis = Theme(
        frame = Theme(
            linecolor = :red,
            frames = ((true, false), (true, false))
        )
    )
)


AbstractPlotting.set_theme!(newtheme)
scene = scatter(rand(100), rand(100))
```
<img width="466" alt="skaermbillede 2018-10-30 kl 09 21 48" src="https://user-images.githubusercontent.com/8429802/47704852-44bdf300-dc25-11e8-85cb-e356510a0e4f.png">

I'm not so sure the ordering of `true`s and `false`s is intuitive but not sure what would be either.