### PR TITLE
RFC: Allow recursive merging of Attributes

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -185,11 +185,18 @@ Base.values(x::Attributes) = values(x.attributes)
 Base.iterate(x::Attributes) = iterate(x.attributes)
 Base.iterate(x::Attributes, state) = iterate(x.attributes, state)
 Base.copy(x::Attributes) = Attributes(copy(x.attributes))
-Base.merge(x::Attributes...) = Attributes(merge(map(a-> a.attributes, x)...))
-Base.merge!(x::Attributes...) = Attributes(merge!(map(a-> a.attributes, x)...))
 Base.filter(f, x::Attributes) = Attributes(filter(f, x.attributes))
 Base.empty!(x::Attributes) = (empty!(x.attributes); x)
 Base.length(x::Attributes) = length(x.attributes)
+
+function Base.merge!(x::Attributes...)
+    ret = x[1]
+    for i in 2:length(x)
+        merge_attributes_doublebang!(x[i], ret)
+    end
+    ret
+end
+Base.merge(x::Attributes...) = merge!(copy.(x)...)
 
 @generated hasfield(x::T, ::Val{key}) where {T, key} = :($(key in fieldnames(T)))
 

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -275,6 +275,25 @@ function merge_attributes!(input, theme, rest = Attributes(), merged = Attribute
     return merged, rest
 end
 
+function merge_attributes_doublebang!(input, theme)
+    for key in union(keys(input), keys(theme))
+        if haskey(input, key) && haskey(theme, key)
+            val = input[key]
+            if isa(to_value(val), Attributes)
+                isa(to_value(theme[key]), Attributes) ||
+                    error("$(key) is an Attribute type in only one input object")
+                merge_attributes_doublebang!(to_value(val), to_value(theme[key]))
+            else
+                theme[key] = val
+            end
+        elseif haskey(input, key)
+            theme[key] = input[key]
+        end
+    end
+    return theme
+end
+
+
 function merged_get!(defaults::Function, key, scene, input::Vector{Any})
     return merged_get!(defaults, key, scene, Attributes(input))
 end


### PR DESCRIPTION
Allows:
```julia
a = Theme(color = :red, axis = Theme(frames = ((true, false), (true, false))));
b = Theme(color = :blue, foo = false, axis = Theme(frames = ((false, false), (false, false))));
c = Theme(foo = true, scatter = Theme(color = :red));
merge(a,b,c).attributes
# Dict{Symbol,Observables.Observable} with 4 entries:
#   :color   => Observable{Any}("ob_05", :blue, Any[])
#   :scatter => Observable{Any}("ob_13", Attributes(Dict{Symbol,Observables.Observable}(:color=>Observable{Any}("ob_08", :red, Any[]))), Any[])
#   :axis    => Observable{Any}("ob_03", Attributes(Dict{Symbol,Observables.Observable}(:frames=>Observable{Any}("ob_04", ((false, false), (false, false)), Any…
#   :foo     => Observable{Any}("ob_09", true, Any[])
```
