### PR TITLE
RFC: Implement cycling color palette for series (/plots). Close https://github.com/JuliaPlots/Makie.jl/issues/189

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -361,7 +361,16 @@ function convert_arguments(
     (m,)
 end
 
+struct Palette{N}
+   colors::SArray{Tuple{N},RGBA{Float32},1,N}
+   i::Ref{UInt8}
+   Palette(colors) = new{length(colors)}(SVector{length(colors)}(to_color.(colors)), zero(UInt8))
+end
 
+function convert_attribute(p::Palette{N}, ::key"color") where {N}
+    p.i[] = p.i[] == N + 1 ? one(UInt8) : p.i[] + one(UInt8)
+    p.colors[p.i[]]
+end
 
 convert_attribute(c::Colorant, ::key"color") = convert(RGBA{Float32}, c)
 convert_attribute(c::Symbol, k::key"color") = convert_attribute(string(c), k)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -366,6 +366,7 @@ struct Palette{N}
    i::Ref{UInt8}
    Palette(colors) = new{length(colors)}(SVector{length(colors)}(to_color.(colors)), zero(UInt8))
 end
+Palette(name::Union{String, Symbol}, n = 8) = Palette(to_colormap(name, n))
 
 function convert_attribute(p::Palette{N}, ::key"color") where {N}
     p.i[] = p.i[] == N ? one(UInt8) : p.i[] + one(UInt8)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -368,7 +368,7 @@ struct Palette{N}
 end
 
 function convert_attribute(p::Palette{N}, ::key"color") where {N}
-    p.i[] = p.i[] == N + 1 ? one(UInt8) : p.i[] + one(UInt8)
+    p.i[] = p.i[] == N ? one(UInt8) : p.i[] + one(UInt8)
     p.colors[p.i[]]
 end
 


### PR DESCRIPTION
This allows:
```julia
using AbstractPlotting, Makie
# Palette
new_theme = Theme(
    scatter = Theme(
        color = AbstractPlotting.Palette([:green, :blue, :red]),
        markersize = 0.3
    )
)

AbstractPlotting.set_theme!(new_theme)

scene = scatter(randn(100), randn(100))
scatter!(scene, randn(100), randn(100))
scatter!(scene, randn(100), randn(100))
scatter!(scene, randn(100), randn(100))
```
<img width="466" alt="skaermbillede 2018-10-31 kl 13 19 18" src="https://user-images.githubusercontent.com/8429802/47788058-f2f29700-dd10-11e8-9aec-5b5315c3736b.png">

You can also use a symbol
```julia
using AbstractPlotting, Makie
new_theme2 = Theme(color = AbstractPlotting.Palette(:Dark2), linewidth = 5) #for some reason the `linewidth` here is ignored
AbstractPlotting.set_theme!(new_theme2)

scene2 = plot(1:100, cumsum(randn(100)))
plot!(scene2, 1:100, cumsum(randn(100)))
plot!(scene2, 1:100, cumsum(randn(100)))
plot!(scene2, 1:100, cumsum(randn(100)))
```
<img width="458" alt="skaermbillede 2018-10-31 kl 13 35 13" src="https://user-images.githubusercontent.com/8429802/47788377-d4d96680-dd11-11e8-8bf3-960b1d177a89.png">


But the below doesn't work (or at least it doesn't update the scene) and I don't know if it could with this implementation:
```julia
scene[:color] = AbstractPlotting.Palette(:Dark2)
```

`Palette` should probably also have a nice `show` method and be exported from Makie.
I'm also not 100% sure how this behaves when adding series that are composed by series (plots composed by plots).