### PR TITLE
WIP: allow to use arguments in default theme

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -5,9 +5,9 @@ const Theme = Attributes
 
 Theme(x::AbstractPlot) = x.attributes
 
-default_theme(scene, T::Type, args...) = Attributes()
+default_theme(scene, T; kwargs...) = Attributes()
 
-function default_theme(scene, args...)
+function default_theme(scene; kwargs...)
     light = Vec3f0[Vec3f0(1.0,1.0,1.0), Vec3f0(0.1,0.1,0.1), Vec3f0(0.9,0.9,0.9), Vec3f0(20,20,20)]
     Theme(
         color = theme(scene, :color),
@@ -326,7 +326,7 @@ function (PlotType::Type{<: AbstractPlot{Typ}})(scene::SceneLike, attributes::At
     # PlotType
     FinalType = Combined{Typ, ArgTyp}
 
-    plot_attributes, scene_attributes = merged_get!(()-> default_theme(scene, FinalType, to_value(args_converted)...), plotsym(FinalType), scene, attributes)
+    plot_attributes, scene_attributes = merged_get!(()-> default_theme(scene, FinalType; args = to_value(args_converted)), plotsym(FinalType), scene, attributes)
     trans = get(plot_attributes, :transformation, automatic)
     transformation = if to_value(trans) == automatic
         Transformation(scene)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -5,9 +5,9 @@ const Theme = Attributes
 
 Theme(x::AbstractPlot) = x.attributes
 
-default_theme(scene, T) = Attributes()
+default_theme(scene, T::Type, args...) = Attributes()
 
-function default_theme(scene)
+function default_theme(scene, args...)
     light = Vec3f0[Vec3f0(1.0,1.0,1.0), Vec3f0(0.1,0.1,0.1), Vec3f0(0.9,0.9,0.9), Vec3f0(20,20,20)]
     Theme(
         color = theme(scene, :color),
@@ -326,7 +326,7 @@ function (PlotType::Type{<: AbstractPlot{Typ}})(scene::SceneLike, attributes::At
     # PlotType
     FinalType = Combined{Typ, ArgTyp}
 
-    plot_attributes, scene_attributes = merged_get!(()-> default_theme(scene, FinalType), plotsym(FinalType), scene, attributes)
+    plot_attributes, scene_attributes = merged_get!(()-> default_theme(scene, FinalType, args_converted...), plotsym(FinalType), scene, attributes)
     trans = get(plot_attributes, :transformation, automatic)
     transformation = if to_value(trans) == automatic
         Transformation(scene)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -326,7 +326,7 @@ function (PlotType::Type{<: AbstractPlot{Typ}})(scene::SceneLike, attributes::At
     # PlotType
     FinalType = Combined{Typ, ArgTyp}
 
-    plot_attributes, scene_attributes = merged_get!(()-> default_theme(scene, FinalType, args_converted...), plotsym(FinalType), scene, attributes)
+    plot_attributes, scene_attributes = merged_get!(()-> default_theme(scene, FinalType, to_value(args_converted)...), plotsym(FinalType), scene, attributes)
     trans = get(plot_attributes, :transformation, automatic)
     transformation = if to_value(trans) == automatic
         Transformation(scene)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -129,7 +129,7 @@ macro recipe(theme_func, Tsym::Symbol, args::Symbol...)
         Base.show(io::IO, ::Type{<: $PlotType}) = print(io, $(string(Tsym)), "{...}")
         $(default_plot_signatures(funcname, funcname!, PlotType))
         Base.@__doc__($funcname)
-        AbstractPlotting.default_theme(scene, ::Type{<: $PlotType}) = $(esc(theme_func))(scene)
+        AbstractPlotting.default_theme(scene, ::Type{<: $PlotType}, args...) = $(esc(theme_func))(scene)
         export $PlotType, $funcname, $funcname!
     end
     if !isempty(args)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -129,7 +129,7 @@ macro recipe(theme_func, Tsym::Symbol, args::Symbol...)
         Base.show(io::IO, ::Type{<: $PlotType}) = print(io, $(string(Tsym)), "{...}")
         $(default_plot_signatures(funcname, funcname!, PlotType))
         Base.@__doc__($funcname)
-        AbstractPlotting.default_theme(scene, ::Type{<: $PlotType}, args...) = $(esc(theme_func))(scene)
+        AbstractPlotting.default_theme(scene, ::Type{<: $PlotType}; kwargs...) = $(esc(theme_func))(scene)
         export $PlotType, $funcname, $funcname!
     end
     if !isempty(args)


### PR DESCRIPTION
The `default_theme` function now also gets passed the converted arguments, which allows to customize the theme as a function of the arguments the user is passing , for example:

```julia
density(Surface, rand(100,2))
```

could be instructed to use `Surface` theme.