### PR TITLE
function conversion cleanup

### DIFF
--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -414,8 +414,8 @@ end
 
 convert_arguments(P::Type{<:AbstractPlot}, r::AbstractVector, f::Function) = convert_arguments(P, r, f.(r))
 
-function convert_arguments(P::Type{<:AbstractPlot}, i::Interval, f::Function)
-    convert_arguments(P, PlotUtils.adapted_grid(f, extrema(i)), f)
+function convert_arguments(P::Type{<:AbstractPlot}, i::AbstractInterval, f::Function)
+    convert_arguments(P, PlotUtils.adapted_grid(f, endpoints(i)), f)
 end
 
 

--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -418,7 +418,13 @@ function convert_arguments(P::Type{<:AbstractPlot}, i::AbstractInterval, f::Func
     convert_arguments(P, PlotUtils.adapted_grid(f, endpoints(i)), f)
 end
 
+to_tuple(t::Tuple) = t
+to_tuple(t) = (t,)
 
+function convert_arguments(P::PlotFunc, f::Function, args...; kwargs...)
+    tmp = f(args...; kwargs...) |> to_tuple
+    convert_arguments(P, tmp...)
+end
 
 @recipe(ScatterLines) do scene
     Theme()

--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -412,10 +412,10 @@ function AbstractPlotting.plot!(p::BarPlot)
     )
 end
 
-convert_arguments(P::Type{<:AbstractPlot}, f::Function) = convert_arguments(P, f, -5, 5)
+convert_arguments(P::Type{<:AbstractPlot}, r::AbstractVector, f::Function) = convert_arguments(P, r, f.(r))
 
-function convert_arguments(P::Type{<:AbstractPlot}, f::Function, min::Number, max::Number)
-    convert_arguments(P, f, PlotUtils.adapted_grid(f, (min, max)))
+function convert_arguments(P::Type{<:AbstractPlot}, i::Interval, f::Function)
+    convert_arguments(P, PlotUtils.adapted_grid(f, extrema(i)), f)
 end
 
 


### PR DESCRIPTION
Now the allowed signatures are:

```julia
# x is AbstractInterval, y is function
julia> lines(-pi..pi, sin)

# x is AbstractVector, y is function
julia> lines(-pi:0.1:pi, sin)
````