### PR TITLE
generalize palette

### DIFF
--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -25,6 +25,7 @@ include("interaction/nodes.jl")
 
 # Basic scene/plot/recipe interfaces + types
 include("scenes.jl")
+include("palette.jl")
 include("theming.jl")
 include("recipes.jl")
 include("interfaces.jl")

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -363,18 +363,6 @@ function convert_arguments(
     (m,)
 end
 
-struct Palette{N}
-   colors::SArray{Tuple{N},RGBA{Float32},1,N}
-   i::Ref{UInt8}
-   Palette(colors) = new{length(colors)}(SVector{length(colors)}(to_color.(colors)), zero(UInt8))
-end
-Palette(name::Union{String, Symbol}, n = 8) = Palette(to_colormap(name, n))
-
-function convert_attribute(p::Palette{N}, ::key"color") where {N}
-    p.i[] = p.i[] == N ? one(UInt8) : p.i[] + one(UInt8)
-    p.colors[p.i[]]
-end
-
 convert_attribute(c::Colorant, ::key"color") = convert(RGBA{Float32}, c)
 convert_attribute(c::Symbol, k::key"color") = convert_attribute(string(c), k)
 function convert_attribute(c::String, ::key"color")

--- a/src/palette.jl
+++ b/src/palette.jl
@@ -1,0 +1,21 @@
+struct Palette{S, T<:AbstractVector{S}} <: AbstractVector{S}
+   values::T
+   i::Ref{UInt8}
+   cycle::Bool
+   Palette(values::T; cycle = false) where {T<:AbstractVector} =
+       new{eltype(T), T}(values, Ref{UInt8}(1), cycle)
+end
+
+Palette(name::Union{String, Symbol}, n = 8; kwargs...) = Palette(to_colormap(name, n); kwargs...)
+
+for s in [:(Key), :(Key{:color})]
+    @eval function convert_attribute(p::Palette, key::($s))
+        attr = convert_attribute(p.values[p.i[]], key)
+        p.cycle && (p.i[] = p.i[] == length(p.values) ? one(UInt8) : p.i[] + one(UInt8))
+        attr
+    end
+end
+
+Base.size(p::Palette) = Base.size(p.values)
+
+Base.getindex(p::Palette, i) = p.values[i+p.i[]-1]

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -2,7 +2,7 @@
 const minimal_default = Attributes(
     font = "Dejavu Sans",
     backgroundcolor = RGBAf0(1,1,1,1),
-    color = :black,
+    color = Palette(ColorBrewer.palette("Dark2", 8), cycle = true),
     colormap = :viridis,
     resolution = reasonable_resolution(),
     visible = true,


### PR DESCRIPTION
This adds support for a generic palette type that gets automatically converted to one of its values on `convert_attributes` (either the first value or a cycling one, depending whether it's a cycling palette or not). I'll probably also add some default palettes for the attributes we want to use in Grammar of Graphics (marker, linestyle etc).