### PR TITLE
Mutual exclusive flags/Attributes

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -518,7 +518,7 @@ convert_attribute(r::AbstractVector{<: Quaternionf0}, k::key"rotation") = r
 
 
 
-convert_attribute(x, k::key"colorrange") = Vec2f0(x)
+convert_attribute(x, k::key"colorrange") = x==nothing ? nothing : Vec2f0(x)
 
 convert_attribute(x, k::key"textsize") = Float32(x)
 convert_attribute(x::AbstractVector{T}, k::key"textsize") where T <: Number = el32convert(x)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -85,7 +85,8 @@ Plots a volume. Available algorithms are:
 end
 mutual_exclusive_attributes(::Type{<:Volume}) =
     Dict(:colorrange => :color,
-         :colormap   => :color)
+         :colormap   => :color,
+         )
 
 """
     `surface(x, y, z)`
@@ -563,10 +564,13 @@ function plot!(scene::SceneLike, ::Type{PlotType}, attributes::Attributes, input
     empty!(scene.attributes)
     # transfer the merged attributes from theme and user defined to the scene
     merge!(scene.attributes, nattributes)
-    for (bad, good) in mutual_exclusive_attributes(PlotType)
+    for (at1, at2) in mutual_exclusive_attributes(PlotType)
         #nothing here to get around defaults in GLVisualize
-        if haskey(attributes, good) && haskey(plot_object.attributes, bad)
-            plot_object.attributes[bad] = nothing
+        haskey(attributes, at1) && haskey(attributes, at2) && error("$at1 conflicts with $at2, please specify only one.")
+        if haskey(attributes, at1) && haskey(plot_object.attributes, at2)
+            plot_object.attributes[at2] = nothing
+        elseif haskey(attributes, at2) && haskey(plot_object.attributes, at1)
+            plot_object.attributes[at1] = nothing
         end
     end
     # call user defined recipe overload to fill the plot type


### PR DESCRIPTION
This is an attempt to allow one to specify which flags inside a Recipe are mutually exclusive. This is done to avoid conflicts down the pipeline between different attributes. One example of such conflict existed between `:color, :colormap and :colornorm` when trying to plot a `volume`. 

Now what happens is that when merging the flags of the `Theme` or `Scene` with those of the `plot_object`, a check for user specified attributes is done, and the mutually exclusive ones which were defined in the `Theme` or `Scene` are removed. 