### PR TITLE
widen function recipe signature

### DIFF
--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -444,7 +444,10 @@ function AbstractPlotting.plot!(p::BarPlot)
     )
 end
 
-convert_arguments(P::PlotFunc, r::AbstractVector, f::Function) = convert_arguments(P, r, f.(r))
+function convert_arguments(P::PlotFunc, r::AbstractVector, f::Function)
+    ptype = plottype(P, Lines)
+    to_plotspec(ptype, convert_arguments(ptype, r, f.(r)))
+end
 
 function convert_arguments(P::PlotFunc, i::AbstractInterval, f::Function)
     convert_arguments(P, PlotUtils.adapted_grid(f, endpoints(i)), f)

--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -444,9 +444,9 @@ function AbstractPlotting.plot!(p::BarPlot)
     )
 end
 
-convert_arguments(P::Type{<:AbstractPlot}, r::AbstractVector, f::Function) = convert_arguments(P, r, f.(r))
+convert_arguments(P::PlotFunc, r::AbstractVector, f::Function) = convert_arguments(P, r, f.(r))
 
-function convert_arguments(P::Type{<:AbstractPlot}, i::AbstractInterval, f::Function)
+function convert_arguments(P::PlotFunc, i::AbstractInterval, f::Function)
     convert_arguments(P, PlotUtils.adapted_grid(f, endpoints(i)), f)
 end
 


### PR DESCRIPTION
I thought for consistency with other recipes, this should actually dispatch on `PlotFunc` rather than `Type{<:AbstractPlot}`