### PR TITLE
add default_palettes

### DIFF
--- a/src/basic_recipes/multiple.jl
+++ b/src/basic_recipes/multiple.jl
@@ -40,14 +40,14 @@ function convert_arguments(P::PlotFunc, m::PlotList)
     PlotSpec{MultiplePlot}(pl)
 end
 
-combine(o1, o2, o3) = o3
+combine(val1, val2; palette = nothing) = val2
 
 function combine!(theme1::Theme, theme2::Theme)
     palette = get(theme1, :palette, current_default_theme()[:palette])
     for (key, val) in theme2
-        o1 = get(theme1, key, nothing)
-        o2 = get(palette, key, nothing)
-        theme1[key] = lift(combine, to_node(o1), to_node(o2), val)
+        tv = get(theme1, key, nothing) |> to_node
+        pv = get(palette, key, nothing) |> to_node
+        theme1[key] = lift((t, p, v) -> combine(t, v, palette = p), tv, pv, val)
     end
     theme1
 end

--- a/src/basic_recipes/multiple.jl
+++ b/src/basic_recipes/multiple.jl
@@ -40,16 +40,14 @@ function convert_arguments(P::PlotFunc, m::PlotList)
     PlotSpec{MultiplePlot}(pl)
 end
 
-combine(o1, o2) = o2
-combine(o) = o
+combine(o1, o2, o3) = o3
 
 function combine!(theme1::Theme, theme2::Theme)
+    palette = get(theme1, :palette, current_default_theme()[:palette])
     for (key, val) in theme2
-        if key in keys(theme1)
-            theme1[key] = lift(combine, theme1[key], val)
-        else
-            theme1[key] = lift(combine, val)
-        end
+        o1 = get(theme1, key, nothing)
+        o2 = get(palette, key, nothing)
+        theme1[key] = lift(combine, to_node(o1), to_node(o2), val)
     end
     theme1
 end

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -147,7 +147,7 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
     Theme(;
         default_theme(scene)...,
         marker = theme(scene, :marker),
-        markersize = 0.1,
+        markersize = theme(scene, :markersize),
         strokecolor = RGBA(0, 0, 0, 0),
         strokewidth = 0.0,
         glowcolor = RGBA(0, 0, 0, 0),
@@ -173,7 +173,7 @@ Plots a mesh for each element in `(x, y, z)`, `(x, y)`, or `positions` (similar 
     Theme(;
         default_theme(scene)...,
         marker = Sphere(Point3f0(0), 1f0),
-        markersize = 0.1,
+        markersize = theme(scene, :markersize),
         rotations = Quaternionf0(0, 0, 0, 1),
         colormap = theme(scene, :colormap),
         colorrange = automatic,

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -104,7 +104,7 @@ Creates a connected line plot for each element in `(x, y, z)`, `(x, y)` or `posi
         linewidth = 1.0,
         colormap = theme(scene, :colormap),
         colorrange = automatic,
-        linestyle = nothing,
+        linestyle = theme(scene, :linestyle),
         fxaa = false
     )
 end
@@ -146,7 +146,7 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
 @recipe(Scatter) do scene
     Theme(;
         default_theme(scene)...,
-        marker = Circle,
+        marker = theme(scene, :marker),
         markersize = 0.1,
         strokecolor = RGBA(0, 0, 0, 0),
         strokewidth = 0.0,

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -1,9 +1,33 @@
+#=
+Conservative 7-color palette from Points of view: Color blindness, Bang Wong - Nature Methods
+https://www.nature.com/articles/nmeth.1618?WT.ec_id=NMETH-201106
+=#
+
+const wong_colors = [
+    AbstractPlotting.RGB(230/255, 159/255, 0/255),
+    AbstractPlotting.RGB(86/255, 180/255, 233/255),
+    AbstractPlotting.RGB(0/255, 158/255, 115/255),
+    AbstractPlotting.RGB(240/255, 228/255, 66/255),
+    AbstractPlotting.RGB(0/255, 114/255, 178/255),
+    AbstractPlotting.RGB(213/255, 94/255, 0/255),
+    AbstractPlotting.RGB(204/255, 121/255, 167/255),
+]
+
+const default_palettes = Attributes(
+    color = wong_colors,
+    marker = [:circle, :xcross, :utriangle, :diamond, :dtriangle, :star8, :pentagon, :rect],
+    linestyle = [nothing, :dash, :dot, :dashdot, :dashdotdot],
+    side = [:left, :right]
+)
 
 const minimal_default = Attributes(
+    palette = default_palettes,
     font = "Dejavu Sans",
     backgroundcolor = RGBAf0(1,1,1,1),
     color = :black,
     colormap = :viridis,
+    marker = Circle,
+    linestyle = nothing,
     resolution = reasonable_resolution(),
     visible = true,
     clear = true,

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -4,13 +4,13 @@ https://www.nature.com/articles/nmeth.1618?WT.ec_id=NMETH-201106
 =#
 
 const wong_colors = [
-    AbstractPlotting.RGB(230/255, 159/255, 0/255),
-    AbstractPlotting.RGB(86/255, 180/255, 233/255),
-    AbstractPlotting.RGB(0/255, 158/255, 115/255),
-    AbstractPlotting.RGB(240/255, 228/255, 66/255),
-    AbstractPlotting.RGB(0/255, 114/255, 178/255),
-    AbstractPlotting.RGB(213/255, 94/255, 0/255),
-    AbstractPlotting.RGB(204/255, 121/255, 167/255),
+    RGB(230/255, 159/255, 0/255),
+    RGB(86/255, 180/255, 233/255),
+    RGB(0/255, 158/255, 115/255),
+    RGB(240/255, 228/255, 66/255),
+    RGB(0/255, 114/255, 178/255),
+    RGB(213/255, 94/255, 0/255),
+    RGB(204/255, 121/255, 167/255),
 ]
 
 const default_palettes = Attributes(

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -27,6 +27,7 @@ const minimal_default = Attributes(
     color = :black,
     colormap = :viridis,
     marker = Circle,
+    markersize = 0.1,
     linestyle = nothing,
     resolution = reasonable_resolution(),
     visible = true,


### PR DESCRIPTION
This adds palettes to the theme, as proposed in https://github.com/JuliaPlots/AbstractPlotting.jl/pull/45#issuecomment-442474327. We dodge the problem of cycling (to be implemented later) but overall this is a much cleaner implementation than #45

I'm moving StatsMakie default scales here so that they can be easily themable. In the future we can thing of which other attributes could have a default palette.