### PR TITLE
define product on Combined

### DIFF
--- a/src/basic_recipes/multiple.jl
+++ b/src/basic_recipes/multiple.jl
@@ -66,7 +66,7 @@ function plot!(p::Combined{multipleplot, <:Tuple{PlotList}})
 end
 
 function default_theme(scene, ::Type{<:Combined{S, T}}) where {S<:Tuple, T}
-    merge((default_theme(scene, pt) for pt in S.parameters)...)
+    merge((default_theme(scene, Combined{pt}) for pt in S.parameters)...)
 end
 
 function plot!(p::Combined{S, <:Tuple{Vararg{Any, N}}}) where {S <: Tuple, N}

--- a/src/basic_recipes/multiple.jl
+++ b/src/basic_recipes/multiple.jl
@@ -64,3 +64,20 @@ function plot!(p::Combined{multipleplot, <:Tuple{PlotList}})
         plot!(p, plottype(s), attr, s.args...)
     end
 end
+
+function default_theme(scene, ::Type{<:Combined{S, T}}) where {S<:Tuple, T}
+    merge((default_theme(scene, pt) for pt in S.parameters)...)
+end
+
+function plot!(p::Combined{S, <:Tuple{Vararg{Any, N}}}) where {S <: Tuple, N}
+    for pt in S.parameters
+        plot!(p, Combined{pt}, Theme(p), p[1:N]...)
+    end
+end
+
+function Base.:*(::Type{<:Combined{S}}, ::Type{<:Combined{T}}) where {S, T}
+    params1 = S isa Function ? [S] : S.params
+    params2 = T isa Function ? [T] : T.params
+    params = union(params1, params2) |> Tuple
+    Combined{Tuple{params...}}
+end

--- a/src/basic_recipes/multiple.jl
+++ b/src/basic_recipes/multiple.jl
@@ -76,8 +76,8 @@ function plot!(p::Combined{S, <:Tuple{Vararg{Any, N}}}) where {S <: Tuple, N}
 end
 
 function Base.:*(::Type{<:Combined{S}}, ::Type{<:Combined{T}}) where {S, T}
-    params1 = S isa Function ? [S] : S.parameters
-    params2 = T isa Function ? [T] : T.parameters
+    params1 = S isa Type{<:Tuple} ? S.parameters : [S]
+    params2 = T isa Type{<:Tuple} ? T.parameters : [T]
     params = union(params1, params2)
     Combined{Tuple{params...}}
 end

--- a/src/basic_recipes/multiple.jl
+++ b/src/basic_recipes/multiple.jl
@@ -78,6 +78,6 @@ end
 function Base.:*(::Type{<:Combined{S}}, ::Type{<:Combined{T}}) where {S, T}
     params1 = S isa Function ? [S] : S.params
     params2 = T isa Function ? [T] : T.params
-    params = union(params1, params2) |> Tuple
+    params = union(params1, params2)
     Combined{Tuple{params...}}
 end

--- a/src/basic_recipes/multiple.jl
+++ b/src/basic_recipes/multiple.jl
@@ -76,8 +76,8 @@ function plot!(p::Combined{S, <:Tuple{Vararg{Any, N}}}) where {S <: Tuple, N}
 end
 
 function Base.:*(::Type{<:Combined{S}}, ::Type{<:Combined{T}}) where {S, T}
-    params1 = S isa Function ? [S] : S.params
-    params2 = T isa Function ? [T] : T.params
+    params1 = S isa Function ? [S] : S.parameters
+    params2 = T isa Function ? [T] : T.parameters
     params = union(params1, params2)
     Combined{Tuple{params...}}
 end


### PR DESCRIPTION
In the spirit of ggplot2, here is a simple way to define product on `Combined`, so that the user con put a few of those together. I find it useful because it feels a bit artificial to define things like `scatterlines` to have both lines and scatter already. Here for example one could do:

```julia
plot(Scatter*Lines, -pi..pi, sin)
```
![screenshot from 2018-11-30 15-34-23](https://user-images.githubusercontent.com/6333339/49298515-81e00400-f4b5-11e8-8327-e33d60c7ee15.png)

or:
```julia
julia> plot(BarPlot*Lines, histogram(nbins = 20), linewidth = 3, randn(1000))
```
![screenshot from 2018-11-30 15-34-36](https://user-images.githubusercontent.com/6333339/49298517-860c2180-f4b5-11e8-8abd-3841072ab6c7.png)

It's actually useful for performance in StatsMakie because I can do the grouping of the arguments only once.