### PR TITLE
fix `on(f, camera, node)`

### DIFF
--- a/src/camera/camera.jl
+++ b/src/camera/camera.jl
@@ -34,7 +34,8 @@ function (cl::CameraLift{F, Args})(val) where {F, Args}
 end
 
 """
-When mapping over nodes for the camera, we store them in the steering_node vector,
+    on(f, c::Camera, nodes::Node...)
+When mapping over nodes for the camera, we store them in the `steering_node` vector,
 to make it easier to disconnect the camera steering signals later!
 """
 function Observables.on(f, c::Camera, nodes::Node...)


### PR DESCRIPTION
having an additional docstring *without* the function call signature is extremely confusing.