### PR TITLE
bump version to reflect tag

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractPlotting"
 uuid = "537997a7-5e4e-5d89-9595-2241ea00577e"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 ColorBrewer = "a2cac450-b92f-5266-8821-25eda20663c8"


### PR DESCRIPTION
Makie.jl requires >= 0.9.2 of AbstractPlotting but the tagged version (and master) don't declare 0.9.2