### PR TITLE
flip the colorbar to make it coherent with the colormap scale

### DIFF
--- a/src/basic_recipes/legend.jl
+++ b/src/basic_recipes/legend.jl
@@ -158,7 +158,7 @@ function plot!(plot::ColorLegend)
     mesh = GLNormalUVMesh(
         vertices = copy(vertices),
         faces = GLTriangle[(1, 2, 3), (3, 4, 1)],
-        texturecoordinates = UV{Float32}[(0, 0), (0, 1), (0, 1), (0, 0)]
+        texturecoordinates = UV{Float32}[(0, 1), (0, 0), (0, 0), (0, 1)]
     )
 
     cmap_node = lift(colormap) do cmap


### PR DESCRIPTION
The current implementation of `colorlegend` results in inverted colorbars. As an example the function exp(-(x^2 + y^2)) yields the following meshplot
![testmesh](https://user-images.githubusercontent.com/20283877/51687524-ff764b00-1ff2-11e9-8fc1-43f98542772e.png)

This pr fixes this problem as shown in the figure below
![testmesh_fixed](https://user-images.githubusercontent.com/20283877/51687853-a9ee6e00-1ff3-11e9-859b-e9d8832ac94c.png)
