### PR TITLE
Add a `framerate` optional argument to all recording

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -206,14 +206,15 @@ end
 
 
 """
-    VideoStream(scene::Scene, dir = mktempdir(), name = "video")
+    VideoStream(scene::Scene, dir = mktempdir(), name = "video"; fps = 24)
 
 returns a stream and a buffer that you can use to not allocate for new frames.
 Use `add_frame!(stream, window, buffer)` to add new video frames to the stream.
 Use `save(stream)` to save the video to 'dir/name.mkv'. You can also call
 `save(stream, "mkv")`, `save(stream, "mp4")`, `save(stream, "gif")` or `save(stream, "webm")` to convert the stream to those formats.
 """
-function VideoStream(scene::Scene)
+function VideoStream(scene::Scene; 
+                     fps::Int = 24)
     if !has_ffmpeg[]
         error("You can't create a video stream without ffmpeg installed.
          Please install ffmpeg, e.g. via https://ffmpeg.org/download.html.
@@ -230,7 +231,7 @@ function VideoStream(scene::Scene)
     _xdim, _ydim = widths(pixelarea(scene)[])
     xdim = _xdim % 2 == 0 ? _xdim : _xdim + 1
     ydim = _ydim % 2 == 0 ? _ydim : _ydim + 1
-    process = open(`ffmpeg -loglevel quiet -f rawvideo -pixel_format rgb24 -r 24 -s:v $(xdim)x$(ydim) -i pipe:0 -vf vflip -y $path`, "w")
+    process = open(`ffmpeg -loglevel quiet -f rawvideo -pixel_format rgb24 -r $fps -s:v $(xdim)x$(ydim) -i pipe:0 -vf vflip -y $path`, "w")
     VideoStream(process.in, process, screen, abspath(path))
 end
 
@@ -257,7 +258,7 @@ function recordframe!(io::VideoStream)
 end
 
 """
-    save(path::String, io::VideoStream)
+    save(path::String, io::VideoStream; fps = 24)
 
 Flushes the video stream and converts the file to the extension found in `path` which can
 be `mkv` is default and doesn't need convert, `gif`, `mp4` and `webm`.
@@ -265,7 +266,8 @@ be `mkv` is default and doesn't need convert, `gif`, `mp4` and `webm`.
 `webm` yields the smallest file size, `mp4` and `mk4` are marginally bigger and `gif`s are up to
 6 times bigger with same quality!
 """
-function save(path::String, io::VideoStream)
+function save(path::String, io::VideoStream;
+              fps::Int = 24)
     close(io.process)
     wait(io.process)
     p, typ = splitext(path)
@@ -274,9 +276,9 @@ function save(path::String, io::VideoStream)
     elseif typ == ".mp4"
         run(`ffmpeg -loglevel quiet -i $(io.path) -c:v libx264 -preset slow -crf 24 -pix_fmt yuv420p -c:a libvo_aacenc -b:a 128k -y $path`)
     elseif typ == ".webm"
-        run(`ffmpeg -loglevel quiet -i $(io.path) -c:v libvpx-vp9 -threads 16 -b:v 2000k -c:a libvorbis -threads 16 -vf scale=iw:ih -y $path`)
+        run(`ffmpeg -loglevel quiet -i $(io.path) -c:v libvpx-vp9 -threads 16 -b:v 2000k -c:a libvorbis -threads 16 -r $fps -vf scale=iw:ih -y $path`)
     elseif typ == ".gif"
-        filters = "fps=15,scale=iw:ih:flags=lanczos"
+        filters = "fps=$fps,scale=iw:ih:flags=lanczos"
         palette_path = dirname(io.path)
         pname = joinpath(palette_path, "palette.bmp")
         isfile(pname) && rm(pname, force = true)
@@ -293,7 +295,7 @@ end
 
 
 """
-    record(func, scene, path)
+    record(func, scene, path; fps = 24)
 usage:
 ```example
     record(scene, "test.gif") do io
@@ -304,10 +306,10 @@ usage:
     end
 ```
 """
-function record(func, scene, path)
-    io = VideoStream(scene)
+function record(func, scene, path; fps::Int = 24)
+    io = VideoStream(scene; fps = fps)
     func(io)
-    save(path, io)
+    save(path, io; fps = fps)
 end
 
 """
@@ -319,7 +321,7 @@ usage:
     end
 ```
 """
-function record(func, scene, path, iter)
+function record(func, scene, path, iter; fps::Int = 24)
     io = VideoStream(scene)
     for i in iter
         t1 = time()
@@ -332,7 +334,7 @@ function record(func, scene, path, iter)
             yield()
         end
     end
-    save(path, io)
+    save(path, io, fps = fps)
 end
 
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -274,7 +274,7 @@ function save(path::String, io::VideoStream;
     if typ == ".mkv"
         cp(io.path, out)
     elseif typ == ".mp4"
-        run(`ffmpeg -loglevel quiet -i $(io.path) -c:v libx264 -preset slow -crf 24 -pix_fmt yuv420p -c:a libvo_aacenc -b:a 128k -y $path`)
+        run(`ffmpeg -loglevel quiet -i $(io.path) -c:v libx264 -preset slow -crf $fps -pix_fmt yuv420p -c:a libvo_aacenc -b:a 128k -y $path`)
     elseif typ == ".webm"
         run(`ffmpeg -loglevel quiet -i $(io.path) -c:v libvpx-vp9 -threads 16 -b:v 2000k -c:a libvorbis -threads 16 -r $fps -vf scale=iw:ih -y $path`)
     elseif typ == ".gif"
@@ -322,7 +322,7 @@ usage:
 ```
 """
 function record(func, scene, path, iter; fps::Int = 24)
-    io = VideoStream(scene)
+    io = VideoStream(scene; fps = fps)
     for i in iter
         t1 = time()
         func(i)


### PR DESCRIPTION
`ffmpeg` only functions correctly when the input and output framerates are the same by [this bug report](https://trac.ffmpeg.org/ticket/3856), so the `framerate` option, type set to `Int` and default value 24, is passed to both the `VideoStream` and `save` functions.

~Please note that this PR is by no means final, and I haven't done testing on it yet; I'm just putting it out there for feedback.~