### PR TITLE
Make signed distance function of text have unit scaling

### DIFF
--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -211,6 +211,7 @@ function render(atlas::TextureAtlas, glyph::Char, font, downsample = 5, pad = 8)
     end
     bitmap, extent = renderface(font, glyph, (50*downsample, 50*downsample))
     sd = sdistancefield(bitmap, downsample, downsample*pad)
+    sd = sd ./ downsample;
     extent = extent ./ Vec2f0(downsample)
     rect = SimpleRectangle(0, 0, size(sd)...)
     uv = push!(atlas.rectangle_packer, rect) #find out where to place the rectangle


### PR DESCRIPTION
With this change, the scale is one unit per pixel, rather than depending
on the internal implementation detal of how much downsampling is done.

This is important if other packages like GLMakie want to rely on the
scale factor for antialiasing, etc.

The antialiasing PR at GLMakie depends on this PR being merged first.
XRef: https://github.com/JuliaPlots/GLMakie.jl/pull/21