### PR TITLE
Export a method `save` from AbstractPlotting

### DIFF
--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -142,6 +142,10 @@ export plot!, plot
 export Stepper, step!, replay_events, record_events, RecordEvents, record, VideoStream
 export VideoStream, recordframe!, record
 
+# saving functions
+
+export save
+
 # default icon for Makie
 function icon()
     path = joinpath(dirname(pathof(AbstractPlotting)), "..", "assets", "icons")

--- a/src/display.jl
+++ b/src/display.jl
@@ -125,6 +125,10 @@ function FileIO.save(filename::String, scene::Scene)
         show(IOContext(s, :full_fidelity => true), MIME"image/png"(), scene)
     end
 end
+
+# here we define a `save` method which can be exported by 
+save(filename::String, scene::Scene) = FileIO.save(filename, scene)
+
 """
     step!(s::Stepper)
 steps through a `Makie.Stepper` and outputs a file with filename `filename-step.jpg`.


### PR DESCRIPTION
This is meant to (a) bring AbstractPlotting in line with the documentation and (b) make it simpler to save.  As of now, we have to import FileIO in order to save.  However, it is much simpler in my opinion to simply export a save function from AbstractPlotting so you don't have to load any extraneous packages.