### PR TITLE
Print scientific notation in `slider`

### DIFF
--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -115,7 +115,6 @@ export disconnect!, must_update, force_update!
 
 # gui
 export slider, button, playbutton
-export default_printer, sig_printer
 
 # Raymarching algorithms
 export RaymarchAlgorithm, IsoValue, Absorption, MaximumIntensityProjection, AbsorptionRGBA, IndexedAbsorptionRGBA

--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -9,6 +9,7 @@ using Serialization # serialize events
 using FreeType, FreeTypeAbstraction, UnicodeFun
 using LinearAlgebra, Statistics
 import ImageMagick, FileIO
+using Printf: @sprintf # @sprintf macro is required for scientific notation
 
 using Base: RefValue
 using Base.Iterators: repeated, drop

--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -115,6 +115,7 @@ export disconnect!, must_update, force_update!
 
 # gui
 export slider, button, playbutton
+export default_printer, sig_printer
 
 # Raymarching algorithms
 export RaymarchAlgorithm, IsoValue, Absorption, MaximumIntensityProjection, AbsorptionRGBA, IndexedAbsorptionRGBA

--- a/src/interaction/gui.jl
+++ b/src/interaction/gui.jl
@@ -1,6 +1,32 @@
 
+
+"""
+    default_printer(v)
+
+Prints v rounded to three digits.  Here, `v` can be of any type accepted by `round`, which includes Real, Complex and many others.  To use your own custom datatype it is sufficient to define Base.round(x::NewType, r::RoundingMode).
+"""
 default_printer(v) = string(round(v, sigdigits=3))
 
+"""
+    sig_printer(v::Real)
+
+Prints the first three significant digits of `v` in scientific notation.
+```jldoctest
+julia> -5:5 .|> exp .|> sig_printer
+11-element Array{String,1}:
+ "6.74e-03"
+ "1.83e-02"
+ "4.98e-02"
+ "1.35e-01"
+ "3.68e-01"
+ "1.00e+00"
+ "2.72e+00"
+ "7.39e+00"
+ "2.01e+01"
+ "5.46e+01"
+ "1.48e+02"
+```
+"""
 sig_printer(v::Real) = @sprintf "%0.2e" v
 
 @recipe(Slider) do scene

--- a/src/interaction/gui.jl
+++ b/src/interaction/gui.jl
@@ -1,8 +1,5 @@
 
-default_printer(v) = string(round(v, digits=3))  # normal round, too low leads to all zeros
-
-sig_printer(v) = string(round(v, sigdigits=3))   # sig-digit round, too loy or high means scientific notation
-
+default_printer(v) = string(round(v, digits=3))
 @recipe(Slider) do scene
     Theme(
         value = 0,

--- a/src/interaction/gui.jl
+++ b/src/interaction/gui.jl
@@ -1,5 +1,8 @@
 
-default_printer(v) = string(round(v, digits=3))
+default_printer(v) = string(round(v, digits=3))  # normal round, too low leads to all zeros
+
+sig_printer(v) = string(round(v, sigdigits=3))   # sig-digit round, too loy or high means scientific notation
+
 @recipe(Slider) do scene
     Theme(
         value = 0,

--- a/src/interaction/gui.jl
+++ b/src/interaction/gui.jl
@@ -1,5 +1,5 @@
 
-default_printer(v) = string(round(v, digits=3))
+default_printer(v) = string(round(v, sigdigits=3))
 @recipe(Slider) do scene
     Theme(
         value = 0,

--- a/src/interaction/gui.jl
+++ b/src/interaction/gui.jl
@@ -1,5 +1,8 @@
 
 default_printer(v) = string(round(v, sigdigits=3))
+
+sig_printer(v::Real) = @sprintf "%0.2e" v
+
 @recipe(Slider) do scene
     Theme(
         value = 0,


### PR DESCRIPTION
Currently, the status is that the `default_printer` will print in normal numbers but revert to scientific notation if the number gets too small, to fix JuliaPlots/Makie.jl#241.  However, I would also like to implement a `sci_printer` to print scientific notation always, though I haven't quite figured out how to do that with round (hence the draft PR.