### PR TITLE
widgets integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ SignedDistanceFields = "73760f76-fbc4-59ce-8f25-708e95d2df96"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UnicodeFun = "1cfade01-22cf-5700-b092-accc4b62d6e1"
+Widgets = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
 
 [compat]
 GeometryTypes = ">=0.7.2"

--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ Widgets = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
 
 [compat]
 GeometryTypes = ">=0.7.2"
+Widgets = ">=0.5.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/REQUIRE
+++ b/REQUIRE
@@ -18,4 +18,4 @@ FileIO
 FixedPointNumbers
 Contour
 ImageMagick
-Widgets 0.5.0
+Widgets 0.5.1

--- a/REQUIRE
+++ b/REQUIRE
@@ -18,3 +18,4 @@ FileIO
 FixedPointNumbers
 Contour
 ImageMagick
+Widgets 0.5.0

--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -61,6 +61,7 @@ include("basic_recipes/legend.jl")
 include("interaction/events.jl")
 include("interaction/gui.jl")
 include("interaction/interactive_api.jl")
+include("interaction/widgets.jl")
 
 # documentation and help functions
 include("documentation/documentation.jl")

--- a/src/interaction/widgets.jl
+++ b/src/interaction/widgets.jl
@@ -13,7 +13,8 @@ function Widgets.slider(::MakieBackend, range; label = nothing)
     Widget{:slider}([:label => label], output = val, layout = _ -> scn)
 end
 
-render(x) = x
-render(w::Widget) = Widgets.render(w)
+function Base.convert(::Type{S}, w::Widget) where {S <: Scene}
+    convert(S, Widgets.render(w))
+end
 
 Widgets.manipulatelayout(::MakieBackend) = hbox

--- a/src/interaction/widgets.jl
+++ b/src/interaction/widgets.jl
@@ -1,0 +1,21 @@
+import Widgets
+using Widgets: Widget
+
+struct MakieBackend <: Widgets.AbstractBackend; end
+
+function Widgets.slider(::MakieBackend, range; label = nothing)
+    if label === nothing
+        scn = slider(range, raw = true, camera = campixel!)
+        val = scn[end][:value]
+    else
+        scn, val = textslider(range, label)
+    end
+    Widget{:slider}([:label => label], output = val, layout = _ -> scn)
+end
+
+render(w::Widget) = w.layout(w)
+
+Base.show(io::IO, x::Widget) = show(io, render(x))
+Base.display(w::Widget) = display(render(w))
+
+Widgets.manipulatelayout(::MakieBackend) = hbox

--- a/src/interaction/widgets.jl
+++ b/src/interaction/widgets.jl
@@ -13,9 +13,7 @@ function Widgets.slider(::MakieBackend, range; label = nothing)
     Widget{:slider}([:label => label], output = val, layout = _ -> scn)
 end
 
-render(w::Widget) = w.layout(w)
-
-Base.show(io::IO, x::Widget) = show(io, render(x))
-Base.display(w::Widget) = display(render(w))
+render(x) = x
+render(w::Widget) = Widgets.render(w)
 
 Widgets.manipulatelayout(::MakieBackend) = hbox

--- a/src/interaction/widgets.jl
+++ b/src/interaction/widgets.jl
@@ -1,5 +1,5 @@
 import Widgets
-using Widgets: Widget
+using Widgets: Widget, components, observe
 
 struct MakieBackend <: Widgets.AbstractBackend; end
 
@@ -17,4 +17,4 @@ function Base.convert(::Type{S}, w::Widget) where {S <: Scene}
     convert(S, Widgets.render(w))
 end
 
-Widgets.manipulatelayout(::MakieBackend) = hbox
+Widgets.defaultlayout(::MakieBackend) = ui -> hbox(values(components(ui))..., observe(ui))

--- a/src/interaction/widgets.jl
+++ b/src/interaction/widgets.jl
@@ -17,4 +17,8 @@ function Base.convert(::Type{S}, w::Widget) where {S <: Scene}
     convert(S, Widgets.render(w))
 end
 
-Widgets.defaultlayout(::MakieBackend) = ui -> hbox(values(components(ui))..., observe(ui))
+function Base.convert(::Type{S}, ::Nothing) where {S <: Scene}
+    Scene()
+end
+
+Widgets.defaultlayout(::MakieBackend) = ui -> hbox(values(components(ui))..., ui[])

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -180,9 +180,9 @@ function update!(p::Scene)
 end
 
 vbox(plots::Transformable...; kw_args...) = vbox([plots...]; kw_args...)
-vbox(plots...; kw_args...) = vbox([render(plot) for plot in plots]; kw_args...)
+vbox(plots...; kw_args...) = vbox([convert(Scene, plot) for plot in plots]; kw_args...)
 hbox(plots::Transformable...; kw_args...) = hbox([plots...]; kw_args...)
-hbox(plots...; kw_args...) = hbox([render(plot) for plot in plots]; kw_args...)
+hbox(plots...; kw_args...) = hbox([convert(Scene, plot) for plot in plots]; kw_args...)
 
 function hbox(plots::Vector{T}; parent = Scene(clear = false), kw_args...) where T <: Scene
     layout(plots, 2; parent = parent, kw_args...)

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -180,7 +180,9 @@ function update!(p::Scene)
 end
 
 vbox(plots::Transformable...; kw_args...) = vbox([plots...]; kw_args...)
+vbox(plots...; kw_args...) = vbox([render(plot) for plot in plots]; kw_args...)
 hbox(plots::Transformable...; kw_args...) = hbox([plots...]; kw_args...)
+hbox(plots...; kw_args...) = hbox([render(plot) for plot in plots]; kw_args...)
 
 function hbox(plots::Vector{T}; parent = Scene(clear = false), kw_args...) where T <: Scene
     layout(plots, 2; parent = parent, kw_args...)

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -180,9 +180,9 @@ function update!(p::Scene)
 end
 
 vbox(plots::Transformable...; kw_args...) = vbox([plots...]; kw_args...)
-vbox(plots...; kw_args...) = vbox([convert(Scene, plot) for plot in plots]; kw_args...)
+vbox(plots...; kw_args...) = vbox(collect(Iterators.filter(!isempty, (convert(Scene, plot) for plot in plots))); kw_args...)
 hbox(plots::Transformable...; kw_args...) = hbox([plots...]; kw_args...)
-hbox(plots...; kw_args...) = hbox([convert(Scene, plot) for plot in plots]; kw_args...)
+hbox(plots...; kw_args...) = hbox(collect(Iterators.filter(!isempty, (convert(Scene, plot) for plot in plots))); kw_args...)
 
 function hbox(plots::Vector{T}; parent = Scene(clear = false), kw_args...) where T <: Scene
     layout(plots, 2; parent = parent, kw_args...)


### PR DESCRIPTION
Heavily WIP, the plan is to allow:

```julia
@manipulate for i=1:100, j=1:100
    scatter(rand(i), rand(i), markersize = j)
end
```

to work.

There is one thing I'm not sure how I do: the `Widget` type here can render like a scene (in that `Widget.slider(1:100)` displays in a Makie window), but I'm not sure how can I get `hbox(Widget.slider(1:100), Widget.slider(1:100))` to work...

The "type piracy" lines on `Widget` should be moved to Widgets.jl of course (`show`, `display` and `render` methods).