### PR TITLE
Correct axes bug for heatmaps & images

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -235,7 +235,7 @@ and stores the `ClosedInterval` to `n` and `m`, plus the original matrix in a Tu
 """
 function convert_arguments(::SurfaceLike, data::AbstractMatrix)
     n, m = Float32.(size(data))
-    (0f0 .. m, 0f0 .. n, el32convert(data))
+    (0f0 .. n, 0f0 .. m, el32convert(data))
 end
 
 """


### PR DESCRIPTION
As discussed in https://github.com/JuliaPlots/Makie.jl/issues/295 and as a secondary point in https://github.com/JuliaPlots/Makie.jl/issues/205

For this example:
```
image(Makie.logo(), scale_plot = false)
```
Master gives:
![image](https://user-images.githubusercontent.com/1694067/54502267-12750f80-4900-11e9-86bd-af92fbebe663.png)

This PR gives:
![image](https://user-images.githubusercontent.com/1694067/54502276-2456b280-4900-11e9-815f-b76a1c760122.png)

I'm late to the discussion, but my view is that for images, I do think there needs to be `transpose` and `flipyaxis` options that both should default to `true` for use of `image`.
