### PR TITLE
Mark inplace vbox with !

### DIFF
--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -300,7 +300,7 @@ function layout_sizes(scenes, size, dim)
 end
 
 
-function vbox(plots::Vector{T}; kw_args...) where T <: AbstractPlot
+function vbox!(plots::Vector{T}; kw_args...) where T <: AbstractPlot
     N = length(plots)
     w = 0.0
     for idx in 1:N


### PR DESCRIPTION
I found this while looking through the code.
It seem that this function operates inplace and the `!` was left out on accident.
The corresponding `hbox!` function defined below it, has it.