### PR TITLE
[Urgent] Fix colors being converted to colormaps

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -443,10 +443,7 @@ end
 
 convert_attribute(c::Colorant, ::key"color") = convert(RGBA{Float32}, c)
 convert_attribute(c::Symbol, k::key"color") = convert_attribute(string(c), k)
-function convert_attribute(c::String, ::key"color")
-    c in all_gradient_names && return to_colormap(c)
-    parse(RGBA{Float32}, c)
-end
+convert_attribute(c::String, ::key"color") = parse(RGBA{Float32}, c)
 
 # Do we really need all colors to be RGBAf0?!
 convert_attribute(c::AbstractArray{<: Colorant}, k::key"color") = el32convert(c)


### PR DESCRIPTION
Colors were being converted to colormaps seemingly arbitrarily in here:

https://github.com/JuliaPlots/AbstractPlotting.jl/blob/f900f0befce4bd059b7aa795f091e7af5b1bc4ad/src/conversions.jl#L446-L449

With the PlotUtils integration, many seemingly innocent names like `gray` were being parsed as Colormaps.

This PR fixes that and that alone.  Since this bug is breaking master at the moment, it should probably get looked at ASAP.

cc: @mkborregaard @miguelraz

(Simon is on vacation so didn't want to bother him too much :P)

Fixes #105.