### PR TITLE
[WIP] add more themability to Axis3d

### DIFF
--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -131,11 +131,11 @@ end
             font = lift(dim3, theme(scene, :font)),
         ),
 
-        frame = Theme(
+        frame = Theme( # TODO change API?
             linecolor = (grid_color, grid_color, grid_color),
             linewidth = (grid_thickness, grid_thickness, grid_thickness),
             axiscolor = (:black, :black, :black),
-        )
+        ),
     )
 end
 


### PR DESCRIPTION
This PR aims to make it possible to theme an Axis3d similarly to an Axis2d, where the grid can have a linestyle.  This will make it easier to theme them and allow for 'less visible' grid lines in Themes.

This PR is related to JuliaPlots/MakieThemes.jl#10, and must be merged into master before its functionality can work.

TODO list (help wanted):
- [ ] Change API for Axis3D to be consistent with Axis2d (frames v/s grid)
- [ ] Determine which keyword attributes to include
- [x] Look into using `optimize_ticks`
- [ ] Add a tick formatter argument, so that you can have scientific ticks (first step to log scales?)