### PR TITLE
Don't constrain type of angle

### DIFF
--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -22,11 +22,11 @@ function translationmatrix(t::Vec{3, T}) where T
     )
 end
 
-rotate(angle::T, axis::Vec{3, T}) where {T} = rotationmatrix4(qrotation(convert(Array, axis), angle))
+rotate(angle, axis::Vec{3}) = rotationmatrix4(qrotation(convert(Array, axis), angle))
 rotate(::Type{T}, angle::Number, axis::Vec{3}) where {T} = rotate(T(angle), convert(Vec{3, T}, axis))
 
-function rotationmatrix_x(angle::T) where T
-    T0, T1 = zero(T), one(T)
+function rotationmatrix_x(angle)
+    T0, T1 = (0, 1)
     Mat{4}(
         T1, T0, T0, T0,
         T0, cos(angle), sin(angle), T0,
@@ -34,8 +34,8 @@ function rotationmatrix_x(angle::T) where T
         T0, T0, T0, T1
     )
 end
-function rotationmatrix_y(angle::T) where T
-    T0, T1 = zero(T), one(T)
+function rotationmatrix_y(angle)
+    T0, T1 = (0, 1)
     Mat{4}(
         cos(angle), T0, -sin(angle),  T0,
         T0, T1, T0, T0,
@@ -43,8 +43,8 @@ function rotationmatrix_y(angle::T) where T
         T0, T0, T0, T1
     )
 end
-function rotationmatrix_z(angle::T) where T
-    T0, T1 = zero(T), one(T)
+function rotationmatrix_z(angle)
+    T0, T1 = (0, 1)
     Mat{4}(
         cos(angle), sin(angle), T0, T0,
         -sin(angle), cos(angle),  T0, T0,

--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -25,7 +25,7 @@ end
 rotate(angle, axis::Vec{3}) = rotationmatrix4(qrotation(convert(Array, axis), angle))
 rotate(::Type{T}, angle::Number, axis::Vec{3}) where {T} = rotate(T(angle), convert(Vec{3, T}, axis))
 
-function rotationmatrix_x(angle)
+function rotationmatrix_x(angle::Number)
     T0, T1 = (0, 1)
     Mat{4}(
         T1, T0, T0, T0,
@@ -34,7 +34,7 @@ function rotationmatrix_x(angle)
         T0, T0, T0, T1
     )
 end
-function rotationmatrix_y(angle)
+function rotationmatrix_y(angle::Number)
     T0, T1 = (0, 1)
     Mat{4}(
         cos(angle), T0, -sin(angle),  T0,
@@ -43,7 +43,7 @@ function rotationmatrix_y(angle)
         T0, T0, T0, T1
     )
 end
-function rotationmatrix_z(angle)
+function rotationmatrix_z(angle::Number)
     T0, T1 = (0, 1)
     Mat{4}(
         cos(angle), sin(angle), T0, T0,

--- a/src/utilities/quaternions.jl
+++ b/src/utilities/quaternions.jl
@@ -34,7 +34,7 @@ end
 @inline Base.getindex(x::Quaternion, i::Integer) = x.data[i]
 Base.isapprox(x::Quaternion, y::Quaternion) = all((x.data .≈ y.data))
 
-function qrotation(axis::StaticVector{3}, theta::Real)
+function qrotation(axis::StaticVector{3}, theta)
     u = normalize(axis)
     s = sin(theta / 2)
     Quaternion(s * u[1], s * u[2], s * u[3], cos(theta / 2))

--- a/src/utilities/quaternions.jl
+++ b/src/utilities/quaternions.jl
@@ -34,7 +34,7 @@ end
 @inline Base.getindex(x::Quaternion, i::Integer) = x.data[i]
 Base.isapprox(x::Quaternion, y::Quaternion) = all((x.data .≈ y.data))
 
-function qrotation(axis::StaticVector{3}, theta)
+function qrotation(axis::StaticVector{3}, theta::Number)
     u = normalize(axis)
     s = sin(theta / 2)
     Quaternion(s * u[1], s * u[2], s * u[3], cos(theta / 2))

--- a/test/projection_math.jl
+++ b/test/projection_math.jl
@@ -1,0 +1,2 @@
+@test eltype(AbstractPlotting.rotationmatrix_x(1)) == Float64
+@test eltype(AbstractPlotting.rotationmatrix_x(1f0)) == Float32

--- a/test/projection_math.jl
+++ b/test/projection_math.jl
@@ -1,2 +1,4 @@
-@test eltype(AbstractPlotting.rotationmatrix_x(1)) == Float64
-@test eltype(AbstractPlotting.rotationmatrix_x(1f0)) == Float32
+@testset "Projection math" begin
+    @test eltype(AbstractPlotting.rotationmatrix_x(1)) == Float64
+    @test eltype(AbstractPlotting.rotationmatrix_x(1f0)) == Float32 
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using AbstractPlotting
 using Test
 
 include("quaternions.jl")
+include("projection_math.jl")
 
 # if get(ENV, "IS_TRAVIS_CI", "false") == "false"
 #   exit(0);


### PR DESCRIPTION
This allows the use of UnitfulAngles



```julia
using AbstractPlotting
using UnitfulAngles
using StaticArrays

const τ = UnitfulAngles.turn

julia> AbstractPlotting.qrotation(@SVector[1,0,0], 0.25τ)
0.7071067811865476 + 0.7071067811865476im + 0.0jm + 0.0km

julia> AbstractPlotting.rotationmatrix_x(0)
4×4 SArray{Tuple{4,4},Float64,2,16}:
 1.0  0.0   0.0  0.0
 0.0  1.0  -0.0  0.0
 0.0  0.0   1.0  0.0
 0.0  0.0   0.0  1.0

julia> AbstractPlotting.rotationmatrix_x(0.5τ)
4×4 SArray{Tuple{4,4},Float64,2,16}:
 1.0   0.0   0.0  0.0
 0.0  -1.0  -0.0  0.0
 0.0   0.0  -1.0  0.0
 0.0   0.0   0.0  1.0
```

It doesn't seem like the `rotationmatrix_[]` methods are used in this package, but perhaps in a reverse dependency. So I wasn't sure if it was worth it to add a test.