### PR TITLE
 Fix save(path, io::VideoStream) when file type is .mkv 

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -284,7 +284,7 @@ function save(path::String, io::VideoStream;
     wait(io.process)
     p, typ = splitext(path)
     if typ == ".mkv"
-        cp(io.path, path)
+        cp(io.path, path, force=true)
     elseif typ == ".mp4"
         run(`ffmpeg -loglevel quiet -i $(io.path) -c:v libx264 -preset slow -r $framerate -pix_fmt yuv420p -c:a libvo_aacenc -b:a 128k -y $path`)
     elseif typ == ".webm"

--- a/src/display.jl
+++ b/src/display.jl
@@ -284,7 +284,7 @@ function save(path::String, io::VideoStream;
     wait(io.process)
     p, typ = splitext(path)
     if typ == ".mkv"
-        cp(io.path, out)
+        cp(io.path, path)
     elseif typ == ".mp4"
         run(`ffmpeg -loglevel quiet -i $(io.path) -c:v libx264 -preset slow -r $framerate -pix_fmt yuv420p -c:a libvo_aacenc -b:a 128k -y $path`)
     elseif typ == ".webm"


### PR DESCRIPTION
Previously, `save("video.mkv", io)` would fail because `out` wasn't defined.

I also changed the behavior when trying to overwrite an existing file. Previously, trying to overwrite a .mkv file would error out, while doing the same with any of the other supported formats would work just fine.

I'm new to this whole git business, so I was wondering if maybe I should have broken this second change into its own pull request?