### PR TITLE
Update `VideoStream`, `save` docstrings

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -220,7 +220,7 @@ end
 """
     VideoStream(scene::Scene, framerate = 24)
 
-returns a stream and a buffer that you can use to not allocate for new frames.
+Returns a stream and a buffer that you can use, to not allocate for new frames.
 Use `recordframe!(stream)` to add new video frames to the stream.
 Use `save(path, stream; framerate=24)` to save the video.
 """
@@ -271,11 +271,11 @@ end
 """
     save(path::String, io::VideoStream; framerate = 24)
 
-Flushes the video stream and converts the file to the extension found in `path` which can
-be `mkv`, `gif`, `mp4` and `webm`.
-`mkv` is default and doesn't need to convert, `mp4` is recommended for the internet, since it's the most supported format.
-`webm` yields the smallest file size, `mp4` and `mk4` are marginally bigger and `gif`s are up to
-6 times bigger with same quality!
+Flushes the video stream and converts the file to the extension found in `path`, which can
+be `.mkv`, `.gif`, `.mp4` or `.webm`.
+`.mkv` is the default, and doesn't need to convert; `.mp4` is recommended for the internet, since it's the most supported format;
+`.webm` yields the smallest file size. `.mp4` and `.mk4` are marginally bigger and `.gif`s are up to
+6 times bigger with the same quality!
 """
 function save(path::String, io::VideoStream;
               framerate::Int = 24)

--- a/src/display.jl
+++ b/src/display.jl
@@ -218,12 +218,11 @@ end
 
 
 """
-    VideoStream(scene::Scene, dir = mktempdir(), name = "video"; framerate = 24)
+    VideoStream(scene::Scene, framerate = 24)
 
 returns a stream and a buffer that you can use to not allocate for new frames.
-Use `add_frame!(stream, window, buffer)` to add new video frames to the stream.
-Use `save(stream)` to save the video to 'dir/name.mkv'. You can also call
-`save(stream, "mkv")`, `save(stream, "mp4")`, `save(stream, "gif")` or `save(stream, "webm")` to convert the stream to those formats.
+Use `recordframe!(stream)` to add new video frames to the stream.
+Use `save(path, stream; framerate=24)` to save the video.
 """
 function VideoStream(scene::Scene;
                      framerate::Int = 24)
@@ -273,8 +272,8 @@ end
     save(path::String, io::VideoStream; framerate = 24)
 
 Flushes the video stream and converts the file to the extension found in `path` which can
-be `mkv` is default and doesn't need convert, `gif`, `mp4` and `webm`.
-`mp4` is recommended for the internet, since it's the most supported format.
+be `mkv`, `gif`, `mp4` and `webm`.
+`mkv` is default and doesn't need to convert, `mp4` is recommended for the internet, since it's the most supported format.
 `webm` yields the smallest file size, `mp4` and `mk4` are marginally bigger and `gif`s are up to
 6 times bigger with same quality!
 """


### PR DESCRIPTION
The docstring for `VideoStream`'s constructor had references to functions whose names and signatures had changed. 

It also had a lot of (outdated) information about how to use `save`. I deleted most of that as it was redundant with `save`'s docstring.