### PR TITLE
[WIP] Refactor Axis3D

### DIFF
--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -131,10 +131,16 @@ end
             font = lift(dim3, theme(scene, :font)),
         ),
 
+        grid = Theme(
+            linecolor = (grid_color, grid_color, grid_color),
+            linewidth = (grid_thickness, grid_thickness, grid_thickness),
+            linestyle = (nothing, nothing, nothing),
+        )
+
         frame = Theme(
             linecolor = (grid_color, grid_color, grid_color),
             linewidth = (grid_thickness, grid_thickness, grid_thickness),
-            axiscolor = (:black, :black, :black),
+            linestyle = (nothing, nothing, nothing),
         )
     )
 end
@@ -603,9 +609,10 @@ end
 
 
 function plot!(scene::SceneLike, ::Type{<: Axis3D}, attributes::Attributes, args...)
+
     axis, non_plot_kwargs = Axis3D(scene, attributes, args)
     textbuffer = TextBuffer(axis, Point{3}, transparency = true)
-    linebuffer = LinesegmentBuffer(axis, Point{3}, transparency = true)
+    linebuffers = [LinesegmentBuffer(axis, Point{3}, transparency = true) for _ in 1:3]
 
     tstyle, ticks, frame = to_value.(getindex.(axis, (:names, :ticks, :frame)))
     titlevals = getindex.(tstyle, (:axisnames, :textcolor, :textsize, :rotation, :align, :font, :gap))

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -26,7 +26,7 @@ end
 """
 # Plot Recipes in `AbstractPlotting`
 
-There's two types of recipes. *Type recipes* define a simple mapping from a
+There are two types of recipes. *Type recipes* define a simple mapping from a
 user defined type to an existing plot type. *Full recipes* can customize the
 theme and define a custom plotting function.
 


### PR DESCRIPTION
This PR aims to make it possible to theme an Axis3d similarly to an Axis2d, where the grid can have a linestyle.  This will make it easier to theme them and allow for 'less visible' grid lines in Themes.

This PR is related to JuliaPlots/MakieThemes.jl#10, and must be merged into master before its functionality can work.

TODO list (help wanted):
- [ ] Change API for Axis3D to be consistent with Axis2d (frames v/s grid)
- [ ] Determine which keyword attributes to include
- [ ] Add a tick formatter argument, so that you can have scientific ticks (first step to log scales?)
- [ ] Look into `PGFPlots`, `tufte` styling