### PR TITLE
changes to speed up webgl backend

### DIFF
--- a/src/camera/camera2d.jl
+++ b/src/camera/camera2d.jl
@@ -13,7 +13,7 @@ function cam2d!(scene::SceneLike; kw_args...)
             area = node(:area, FRect(0, 0, 1, 1)),
             zoomspeed = 0.10f0,
             zoombutton = nothing,
-            panbutton = Mouse.right,
+            panbutton = Mouse.left,
             selectionbutton = (Keyboard.space, Mouse.left),
             padding = 0.001,
             last_area = Vec(size(scene))

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -564,7 +564,7 @@ convert_attribute(x::NativeFont, k::key"font") = x
 convert_attribute(s::Quaternion, ::key"rotation") = s
 function convert_attribute(s::VecTypes{N}, ::key"rotation") where N
     if N == 4
-        Quaternion(s...)
+        Quaternionf0(s...)
     elseif N == 3
         rotation_between(Vec3f0(0, 0, 1), to_ndim(Vec3f0, s, 0.0))
     elseif N == 2
@@ -578,7 +578,7 @@ end
 function convert_attribute(s::Tuple{VecTypes, AbstractFloat}, ::key"rotation")
     qrotation(to_ndim(Vec3f0, s[1], 0.0), s[2])
 end
-convert_attribute(angle::AbstractFloat, ::key"rotation") = qrotation(Vec3f0(0, 0, 1), angle)
+convert_attribute(angle::AbstractFloat, ::key"rotation") = qrotation(Vec3f0(0, 0, 1), Float32(angle))
 convert_attribute(r::AbstractVector, k::key"rotation") = to_rotation.(r)
 convert_attribute(r::AbstractVector{<: Quaternionf0}, k::key"rotation") = r
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -15,7 +15,10 @@ function inline!(inline = true)
 end
 
 function register_backend!(backend::AbstractBackend)
-    push!(available_backends, backend)
+    if !(backend in available_backends)
+        push!(available_backends, backend)
+    end
+    # only set as the current backend if it's the only one
     if(length(available_backends) == 1)
         current_backend[] = backend
     end

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -297,7 +297,6 @@ function layout_sizes(scenes, size, dim)
     sizes
 end
 
-
 function vbox!(plots::Vector{T}; kw_args...) where T <: AbstractPlot
     N = length(plots)
     w = 0.0

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -220,7 +220,6 @@ end
 
 otherdim(dim) = dim == 1 ? 2 : 1
 
-
 function scaled_width(bb, other_size, dim)
     wh = widths(bb)
     scaling = other_size / wh[otherdim(dim)]

--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -230,7 +230,7 @@ function render(atlas::TextureAtlas, glyph::Char, font, downsample = 5, pad = 8)
     if glyph == '\n' # don't render  newline
         glyph = ' '
     end
-    bitmap, extent = renderface(font, glyph, (30*downsample, 30*downsample))
+    bitmap, extent = renderface(font, glyph, (40*downsample, 40*downsample))
     sd = sdistancefield(bitmap, downsample, downsample*pad)
     sd = sd ./ downsample;
     extent = extent ./ Vec2f0(downsample)

--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -31,7 +31,7 @@ begin #basically a singleton for the textureatlas
         'π','∮','⋅','→','∞','∑','∏','∀','∈','ℝ','⌈','⌉','−','⌊','⌋','α','∧','β','∨','ℕ','⊆','₀',
         '⊂','ℤ','ℚ','ℂ','⊥','≠','≡','≤','≪','⊤','⇒','⇔','₂','⇌','Ω','⌀',
     ]
-    const _cache_path = abspath(first(Base.DEPOT_PATH), "makiegallery", ".cache", "texture_atlas.jls")
+    const _cache_path = abspath(first(Base.DEPOT_PATH), "makiegallery", ".cache", "texture_atlas_web.jls")
     const _default_font = Vector{Ptr{FreeType.FT_FaceRec}}[]
     const _alternative_fonts = Vector{Ptr{FreeType.FT_FaceRec}}[]
 

--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -10,7 +10,7 @@ mutable struct TextureAtlas
     extent          ::Vector{FontExtent{Float64}}
 end
 
-function TextureAtlas(initial_size = (2048, 2048))
+function TextureAtlas(initial_size = (1024, 1024))
     TextureAtlas(
         RectanglePacker(SimpleRectangle(0, 0, initial_size...)),
         Dict{Any, Int}(),
@@ -80,9 +80,9 @@ begin #basically a singleton for the textureatlas
         for c in '\u0000':'\u00ff' #make sure all ascii is mapped linearly
             insert_glyph!(atlas, c, defaultfont())
         end
-        for c in _tobe_cached
-            insert_glyph!(atlas, c, defaultfont())
-        end
+        # for c in _tobe_cached
+        #     insert_glyph!(atlas, c, defaultfont())
+        # end
         to_cache(atlas) # cache it
         return atlas
     end
@@ -209,7 +209,7 @@ function render(atlas::TextureAtlas, glyph::Char, font, downsample = 5, pad = 8)
     if glyph == '\n' # don't render  newline
         glyph = ' '
     end
-    bitmap, extent = renderface(font, glyph, (50*downsample, 50*downsample))
+    bitmap, extent = renderface(font, glyph, (30*downsample, 30*downsample))
     sd = sdistancefield(bitmap, downsample, downsample*pad)
     sd = sd ./ downsample;
     extent = extent ./ Vec2f0(downsample)


### PR DESCRIPTION
Mainly introduces a way, to generate a lower quality texture atlas via: 
```julia
set_glyph_resolution!(Low)
```
Default is high, so shouldn't mess with GLBackend