### PR TITLE
Update types.jl

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -186,7 +186,7 @@ struct Events
     """
     mouseposition::Node{Point2d{Float64}}
     """
-    The
+    The enum value of the mouse drag. 
     """
     mousedrag::Node{Mouse.DragEnum}
     """

--- a/src/types.jl
+++ b/src/types.jl
@@ -186,7 +186,7 @@ struct Events
     """
     mouseposition::Node{Point2d{Float64}}
     """
-    The enum value of the mouse drag. 
+The state of the mouse drag, represented by an enumerator of [`DragEnum`](@ref).
     """
     mousedrag::Node{Mouse.DragEnum}
     """


### PR DESCRIPTION
Not sure if I added the correct info for `mousedrag::Node{Mouse.DragEnum}` but I wanted to add something since previously the docs just said `the`.