### PR TITLE
Allow PlotUtils.ColorGradient to be passed to `colormap`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,6 @@ test:
 
     script:
       - mkdir $JULIA_DEPOT_PATH # Pkg.jl#325
-      - glxinfo | grep 'version'
       - julia -e 'using InteractiveUtils; versioninfo()'
       - julia --project -e 'using Pkg; Pkg.pkg"add Makie#master StatsMakie#master MakieGallery#master GLMakie#master; test"'
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -665,6 +665,11 @@ function convert_attribute(cs::Union{String, Symbol}, ::key"colormap", n::Intege
     end
 end
 
+function AbstractPlotting.convert_attribute(cg::PlotUtils.ColorGradient, ::key"colormap", n::Integer = 30)
+    # PlotUtils does not always give [0, 1] range, so we adapt to what it has
+    return getindex.(Ref(cg), LinRange(first(c.values), last(c.values), n)) # workaround until PlotUtils tags a release
+    # TODO change this once PlotUtils supports collections of indices
+end
 
 
 """


### PR DESCRIPTION
Allows:
```julia
plot(...; ..., colormap = cgrad(:viridis; scale = :log10))
```