### PR TITLE
fix unresponsive button frame

### DIFF
--- a/src/interaction/gui.jl
+++ b/src/interaction/gui.jl
@@ -223,17 +223,31 @@ function plot!(splot::Button)
         dimensions, textcolor, clicks, textsize, position,
         padvalue
     ))
+
+    textpos = lift(position, dimensions) do pos, dims
+        # always center the text in the button
+        # the dims could be smaller than the text though
+        Point2f0(pos .+ dims ./ 2)
+    end
+
     txt = splot[1]
     lplot = text!(
         splot, txt,
         color = textcolor,
-        textsize = textsize, position = position,
-        align = (:bottom, :center)
+        textsize = textsize, position = textpos,
+        align = (:center, :center)
     ).plots[end]
-    bb = boundingbox(lplot)
-    pad = mean(widths(bb)) .* padvalue[]
-    poly!(splot, padrect(FRect2D(boundingbox(lplot)), pad), color = backgroundcolor, strokecolor = strokecolor, strokewidth = strokewidth)
+
+    # position and dimensions
+    box = lift(position, dimensions) do pos, dims
+        FRect(pos, dims)
+    end
+
+    poly!(
+        splot, box,
+        color = backgroundcolor, strokecolor = strokecolor, strokewidth = strokewidth)
     reverse!(splot.plots) # make poly first
+
     on(events(splot).mousebuttons) do mb
         if ispressed(mb, Mouse.left) && mouseover(parent_scene(splot), splot.plots...)
             clicks[] = clicks[] + 1


### PR DESCRIPTION
actually for MakieLayout it would be better to just give a boundingbox instead of position and dims to the button. in makielayout, an element can either report its width and height, or not report it and get auto sized. either way it is supposed to be aligned within a bounding box after. if the bounding box should be bigger than the element wants to be, the element should have a valign and halign attribute to decide where it ends up