### PR TITLE
no Node piracy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ test:
         - apt-get install -y cmake xorg-dev mesa-utils
 
     script:
+      - glxinfo | grep "OpenGL version"
       - mkdir $JULIA_DEPOT_PATH # Pkg.jl#325
       - julia -e 'using InteractiveUtils; versioninfo()'
       - julia --project -e 'using Pkg; Pkg.pkg"add Makie#master StatsMakie#master MakieGallery#master GLMakie#master; test"'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 variables:
     CI_IMAGE_TAG: "xorg"
+    DISPLAY: ":0"
     MODERNGL_DEBUGGING: "true"
     JULIA_DEPOT_PATH: "$CI_PROJECT_DIR/.julia/"
     ABSTRACTPLOTTING_MINIMAL: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,8 @@ variables:
 
 test:
     image: "juliagpu/julia:v1.2-opengl"
+    tags: 
+      - xorg
     before_script:
         - apt-get -qq update
         # glfw

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.9.13"
 
 [deps]
 ColorBrewer = "a2cac450-b92f-5266-8821-25eda20663c8"
+ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"

--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -1,8 +1,9 @@
 module AbstractPlotting
 
 using FFMPEG # get FFMPEG on any system!
-using Observables, GeometryTypes, StaticArrays, ColorTypes, Colors, IntervalSets, PlotUtils
-using ColorBrewer, FixedPointNumbers, Packing, SignedDistanceFields
+using Observables, GeometryTypes, StaticArrays, IntervalSets, PlotUtils
+using ColorBrewer, ColorTypes, Colors, ColorSchemes
+using FixedPointNumbers, Packing, SignedDistanceFields
 using Markdown, DocStringExtensions # documentation
 using Serialization # serialize events
 using StructArrays

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -638,6 +638,10 @@ function convert_attribute(r::Reverse, ::key"colormap")
     reverse(to_colormap(r.data))
 end
 
+function convert_attribute(cs::ColorScheme, ::key"colormap")
+    return to_colormap(cs.colors)
+end
+
 
 """
     to_colormap(b, x)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -196,6 +196,14 @@ function convert_arguments(P::PointBased, x::Rect2D)
     # TODO fix the order of decompose
     convert_arguments(P, decompose(Point2f0, x)[[1, 2, 4, 3, 1]])
 end
+
+function convert_arguments(::Type{<: LineSegments}, x::Rect2D)
+    # TODO fix the order of decompose
+    points = decompose(Point2f0, x)
+    return (points[[1, 2, 2, 4, 4, 3, 3, 1]],)
+end
+
+
 function convert_arguments(P::PointBased, x::Rect3D)
     inds = [
         1, 2, 3, 4, 5, 6, 7, 8,

--- a/src/interaction/nodes.jl
+++ b/src/interaction/nodes.jl
@@ -24,7 +24,7 @@ to_node(x::Node) = x
 signal_convert(::Type{Node{T1}}, x::Node{T1}, name = :node) where T1 = x
 signal_convert(::Type{Node{T1}}, x::Node{T2}, name = :node) where {T1, T2} = lift(convert, Node(T1), x, typ = T1)
 signal_convert(::Type{Node{T1}}, x::T2, name = :node) where {T1, T2} = Node{T1}(convert(T1, x))
-signal_convert(t, x, name = :node) = x
+signal_convert(::Type{Node}, x, name = :node) = Node(x)
 
 node(name, node) = Node(node)
 node(name, node::Node) = lift(identity, node)

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -26,7 +26,7 @@ function Transformation()
         model,
         flip,
         align,
-        signal_convert(Node, identity)
+        signal_convert(Node{Any}, identity)
     )
 end
 
@@ -55,7 +55,7 @@ function Transformation(scene::SceneLike)
         model,
         flip,
         align,
-        signal_convert(Node, identity)
+        signal_convert(Node{Any}, identity)
     )
     return trans
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -254,7 +254,7 @@ struct Transformation <: Transformable
     model::Node{Mat4f0}
     flip::Node{NTuple{3, Bool}}
     align::Node{Vec2f0}
-    data_func::Node{<: Any}
+    data_func::Node{Any}
     function Transformation(translation, scale, rotation, model, flip, align, data_func)
         return new(
             RefValue{Transformable}(),
@@ -286,9 +286,6 @@ value_convert(x::NamedTuple) = Attributes(x)
 
 node_pairs(pair::Union{Pair, Tuple{Any, Any}}) = (pair[1] => to_node(Any, value_convert(pair[2]), pair[1]))
 node_pairs(pairs) = (node_pairs(pair) for pair in pairs)
-Base.convert(::Type{<: Node}, x::T) where T = to_node(T, x)
-Base.convert(::Type{T}, x::T) where T <: Node = x
-Base.convert(::Type{Node{T}}, x::Node) where T = to_node(T, x)
 
 Attributes(; kw_args...) = Attributes(Dict{Symbol, Node}(node_pairs(kw_args)))
 Attributes(pairs::Pair...) = Attributes(Dict{Symbol, Node}(node_pairs(pairs)))


### PR DESCRIPTION
@asinghvi17 jeez... so much depends on the convert definition :D I think to properly fix this, we'll need to move a correct convert definition into Observables.jl, and then move to that version in future AbstractPlotting releases...