### PR TITLE
Better support categorical strings/ints

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -114,7 +114,7 @@ categoric_range(range::Automatic) = range
 categoric_range(range) = 1:length(range)
 
 function categoric_position(x, labels)
-    findfirst(l-> l === x, labels)
+    findfirst(l -> l == x, labels)
 end
 
 categoric_position(x, labels::Automatic) = x


### PR DESCRIPTION
This came up as part of https://github.com/JuliaPlots/StatsMakie.jl/pull/106.

The current default for `categoric_labels` fails when `categoric_labels` does type promotion (which `unique` sometimes does) because it checks for equivalence:

```julia
julia> using AbstractPlotting, RDatasets
julia> d = dataset("Ecdat","Fatality");
julia> d.JailD[1:5]
5-element CategoricalArray{String,1,UInt8}:
 "no"
 "no"
 "no"
 "no"
 "no"
julia> slabels = AbstractPlotting.categoric_labels(d.JailD)
2-element Array{String,1}:
 "no" 
 "yes"
julia> AbstractPlotting.categoric_position.(d.JailD[1:5], Ref(slabels))
5-element Array{Nothing,1}:
 nothing
 nothing
 nothing
 nothing
 nothing
```

It's also a problem if we mix integers:

```julia
julia> a = Any[Int64(1), Int32(1), Int128(2)];
julia> ilabels = AbstractPlotting.categoric_labels(a)
2-element Array{Any,1}:
 1
 2
julia> AbstractPlotting.categoric_position.(a, Ref(ilabels))
3-element Array{Union{Nothing, Int64},1}:
 1       
  nothing
 2       
```

With this PR, we have:

```julia
julia> AbstractPlotting.categoric_position.(d.JailD[1:5], Ref(slabels))
5-element Array{Int64,1}:
 1
 1
 1
 1
 1

julia> AbstractPlotting.categoric_position.(a, Ref(ilabels))
3-element Array{Int64,1}:
 1
 1
 2
```