### PR TITLE
Allow mesh to be passed to poly

### DIFF
--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -36,6 +36,7 @@ $(ATTRIBUTES)
         transparency = false,
     )
 end
+convert_arguments(::Type{<: Poly}, v::AbstractVector{<: AbstractMesh}) = (v,)
 convert_arguments(::Type{<: Poly}, v::AbstractVector{<: VecTypes}) = (v,)
 convert_arguments(::Type{<: Poly}, v::AbstractVector{<: AbstractVector{<: VecTypes}}) = (v,)
 convert_arguments(::Type{<: Poly}, v::AbstractVector{<: Union{Circle, Rectangle, HyperRectangle}}) = (v,)

--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -2,6 +2,7 @@
     `poly(vertices, indices; kwargs...)`
     `poly(points; kwargs...)`
     `poly(shape; kwargs...)`
+    `poly(mesh; kwargs...)`
 
 Plots a polygon based on the arguments given.
 When vertices and indices are given, it functions similarly to `mesh`.


### PR DESCRIPTION
Currently the `convert_arguments` pipeline doesn't permit an `AbstractMesh` to be passed to `poly`, even though that's what the pipelines converts inputs to. This PR just implements a passthrough for `AbstractMesh`.