### PR TITLE
Correct ylabel! behaviour

### DIFF
--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -30,7 +30,7 @@ function ylabel!(scene, ylabel::AbstractString)
     end
     nothing
 end
-ylabel!(ylabel::AbstractString) = xlabel!(current_scene(), ylabel)
+ylabel!(ylabel::AbstractString) = ylabel!(current_scene(), ylabel)
 
 """
     zlabel!([scene,] zlabel)


### PR DESCRIPTION
Dear fellows

When testing the ylabel!("String") shorthand i noticed that the label of the x-axis changed.
To correct this, I changed the function in line 33.

I am not really used to the github workflow, but I hope I could help.

Best Regards