### PR TITLE
use black band by default

### DIFF
--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -563,7 +563,7 @@ $(ATTRIBUTES)
 @recipe(Band, lowerpoints, upperpoints) do scene
     Theme(;
         default_theme(scene, Mesh)...,
-        color = RGBAf0(1.0,0,0,0.2)
+        color = RGBAf0(0.0,0,0,0.2)
     )
 end
 


### PR DESCRIPTION
I think it's a bit odd to have this red by default.

I was also trying to figure out if there is a smart way to have a "alpha" multiplier here somehow. The idea is that in a recipe (things like `ShadedLine` [here](https://github.com/JuliaPlots/StatsMakie.jl/blob/master/src/recipes/shaded_background.jl#L7)) one would really want to let the user be able to control separately the overall color (of the whole plot) and the transparency (specifically of the band).

StatsMakie hacks around it by defining its own recipe with `fillalpha`, but I was curious whether there were smarter solutions.