### PR TITLE
give poly default strokewidth of 1

### DIFF
--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -25,7 +25,7 @@ $(ATTRIBUTES)
         strokecolor = RGBAf0(0,0,0,0),
         colormap = theme(scene, :colormap),
         colorrange = automatic,
-        strokewidth = 0.0,
+        strokewidth = 1.0,
         shading = false,
         # we turn this false for now, since otherwise shapes look transparent
         # since we use meshes, which are drawn into a different framebuffer because of fxaa


### PR DESCRIPTION
If you want to give poly a stroke, you always have to set both strokecolor and strokewidth right now which is quite annoying. I think if you specify a color then a stroke in that color should be visible, then you can still tweak the linewidth but 1 is a good default. It could also be the other way around, but I think it's more natural to think about the color first.

This won't change any plot using only the defaults, because the effect of strokewidth 1 and color = transparent is still an invisible stroke.