### PR TITLE
Allow colorbuffer to be used directly on Scenes

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -393,7 +393,7 @@ Returns the content of the given scene or screen rasterised to a Matrix of
 Colors.  The return type is backend-dependent, but will be some form of RGB
 or RGBA.
 """
-function colorbuffer(sc::Scene)
+function colorbuffer(scene::Scene)
     screen = getscreen(scene)
     if screen === nothing
         error("""

--- a/src/display.jl
+++ b/src/display.jl
@@ -401,10 +401,12 @@ function colorbuffer(scene::Scene)
                 You have not loaded a backend.  Please load one (`using GLMakie` or `using CairoMakie`)
                 before trying to render a Scene.
                 """)
+        else
+            error("""
+                The Scene needs an active screen before a colorbuffer can be rendered from it.
+                Ensure that it has one via `display(scene)`.
+                """)
         end
-        # If the Scene has not been displayed, then explicitly display it.
-        # The backend has to return its screen object anyway, so we can use that.
-        screen = display(scene)
     end
     return colorbuffer(screen)
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -379,8 +379,29 @@ function VideoStream(
     VideoStream(process.in, process, screen, abspath(path))
 end
 
+
+# This has to be overloaded by the backend for its screen type.
 function colorbuffer(x)
     error("colorbuffer not implemented for screen $(typeof(x))")
+end
+
+"""
+    colorbuffer(scene)
+    colorbuffer(screen)
+
+Returns the content of the given scene or screen rasterised to a Matrix of
+Colors.  The return type is backend-dependent, but will be some form of RGB
+or RGBA.
+"""
+function colorbuffer(sc::Scene)
+    screen = getscreen(scene)
+    if screen === nothing
+        error("""
+        It looks like your scene does not have a Screen attached.  
+        Try displaying it explicitly, and ensure that there is an active backend!
+        """)
+    end
+    return colorbuffer(screen)
 end
 
 """

--- a/src/display.jl
+++ b/src/display.jl
@@ -395,11 +395,16 @@ or RGBA.
 """
 function colorbuffer(scene::Scene)
     screen = getscreen(scene)
-    if screen === nothing
-        error("""
-        It looks like your scene does not have a Screen attached.  
-        Try displaying it explicitly, and ensure that there is an active backend!
-        """)
+    if isnothing(screen)
+        if ismissing(current_backend[])
+            error("""
+                You have not loaded a backend.  Please load one (`using GLMakie` or `using CairoMakie`)
+                before trying to render a Scene.
+                """)
+        end
+        # If the Scene has not been displayed, then explicitly display it.
+        # The backend has to return its screen object anyway, so we can use that.
+        screen = display(scene)
     end
     return colorbuffer(screen)
 end


### PR DESCRIPTION
This is something I came across recently as a usecase - of course, it's trivial to do this myself, but I figured it should be an easier-to-use feature.  I actually need to take the Fourier transform of a plot (it's a simulated worm) and I could see someone having this need in the future.

We should also document this in the Gallery.