### PR TITLE
WIP: Adds attribute for setting width of 3D axis lines

### DIFF
--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -117,7 +117,9 @@ $(ATTRIBUTES)
     tick_color = RGBAf0(0.5, 0.5, 0.5, 0.6)
     grid_color = RGBAf0(0.5, 0.5, 0.5, 0.4)
     grid_thickness = 1
+    axis_linewidth = 1.5
     gridthickness = ntuple(x-> 1f0, Val(3))
+    axislinewidth = ntuple(x->1.5f0, Val(3))
     tsize = 5 # in percent
     Attributes(
         visible = true,
@@ -152,6 +154,7 @@ $(ATTRIBUTES)
         frame = Attributes(
             linecolor = (grid_color, grid_color, grid_color),
             linewidth = (grid_thickness, grid_thickness, grid_thickness),
+            axislinewidth = (axis_linewidth, axis_linewidth, axis_linewidth),
             axiscolor = (:black, :black, :black),
         )
     )
@@ -609,7 +612,7 @@ function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
         showaxis, showticks, showgrid,
         axisnames, axisnames_color, axisnames_size, axisrotation, axisalign,
         axisnames_font, titlegap,
-        gridcolors, gridthickness, axiscolors,
+        gridcolors, gridthickness, axislinewidth, axiscolors,
         ttextcolor, trotation, ttextsize, talign, tfont, tgap
     ) = args3d # splat to names
 
@@ -633,7 +636,7 @@ function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
         width = _widths(ranges[i])
         stop = origin .+ (width .* axis_vec)
         if showaxis[i]
-            append!(linebuffer, [origin, stop], color = axiscolors[i], linewidth = 1.5f0)
+            append!(linebuffer, [origin, stop], color = axiscolors[i], linewidth = axislinewidth[i])
         end
         if showticks[i]
             range = ranges[i]
@@ -705,7 +708,7 @@ function plot!(scene::SceneLike, ::Type{<: Axis3D}, attributes::Attributes, args
 
     tstyle, ticks, frame = to_value.(getindex.(axis, (:names, :ticks, :frame)))
     titlevals = getindex.(tstyle, (:axisnames, :textcolor, :textsize, :rotation, :align, :font, :gap))
-    framevals = getindex.(frame, (:linecolor, :linewidth, :axiscolor))
+    framevals = getindex.(frame, (:linecolor, :linewidth, :axislinewidth, :axiscolor))
     tvals = getindex.(ticks, (:textcolor, :rotation, :textsize, :align, :font, :gap))
     args = (
         getindex.(axis, (:showaxis, :showticks, :showgrid))...,


### PR DESCRIPTION
This was partially prompted by a slight confusion in the documentation for Axis3d.frames.linewdith. In the docs, it says that this property controls the width of the axis lines, but in the code it actually sets the width of the gridlines instead. This is my attempt at clearing up that confusion by introducing the property `axislinewidth`, which does what the documentation claims that`linewidth` is supposed to do. 
I have yet to update the actual documentation, since I'm actually not sure how to do that. Of course, any comments and corrections are welcome!