### PR TITLE
Remove global theme support

### DIFF
--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -202,6 +202,11 @@ end
 
 function __init__()
     pushdisplay(PlotDisplay())
+    cfg_path = joinpath(homedir(), ".config", "makie", "theme.jl")
+    if isfile(cfg_path)
+        @warn "The global configuration file is no longer supported."*
+        "Please include the file manually with `include(\"$cfg_path\")` before plotting."
+    end
 end
 
 

--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -200,20 +200,8 @@ function logo()
     FileIO.load(joinpath(dirname(@__DIR__), "assets", "misc", "makie_logo.png"))
 end
 
-const config_file = "theme.jl"
-const config_path = joinpath(homedir(), ".config", "makie", config_file)
-
 function __init__()
     pushdisplay(PlotDisplay())
-    cfg_path = config_path
-    if isfile(cfg_path)
-        theme = include(cfg_path)
-        if theme isa Attributes
-            set_theme!(theme)
-        else
-            @warn("Found config file in $(cfg_path), which doesn't return an instance of Attributes. Ignoring faulty file!")
-        end
-    end
 end
 
 


### PR DESCRIPTION
This breaks on julia 1.5 due to the `include` in `__init__`.
It may be simpler to explicitly have the user do the `include`. See also the corresponding MakieGallery PR