### PR TITLE
add option to use parentheses around expression for @lift

### DIFF
--- a/src/interaction/liftmacro.jl
+++ b/src/interaction/liftmacro.jl
@@ -62,7 +62,7 @@ You can also use parentheses around an expression if that expression evaluates t
 
 ```julia
 nt = (x = Node(1), y = Node(2))
-@lift($(nt.x) + $(nt.y))
+@lift(\$(nt.x) + \$(nt.y))
 ```
 """
 macro lift(exp)

--- a/src/interaction/liftmacro.jl
+++ b/src/interaction/liftmacro.jl
@@ -1,23 +1,21 @@
-nodesym(exp::Expr) = exp.args[1]
-
 """
-Returns a set of all symbols in an expression that look like \$some_symbol
+Returns a set of all sub-expressions in an expression that look like \$some_expression
 """
-function findnodesyms(obj::Expr)
-    nodesymbols = Set{Symbol}()
+function find_node_expressions(obj::Expr)
+    node_expressions = Set()
     if isnodeexpression(obj)
-        push!(nodesymbols, nodesym(obj))
+        push!(node_expressions, obj)
     else
         for a in obj.args
-            nodesymbols = union(nodesymbols, findnodesyms(a))
+            node_expressions = union(node_expressions, find_node_expressions(a))
         end
     end
-    nodesymbols
+    node_expressions
 end
 
-function findnodesyms(x)
-    # empty set if x is not an Expr
-    Set{Symbol}()
+function find_node_expressions(x)
+    # empty dict if x is not an Expr
+    Set()
 end
 
 isnodeexpression(x) = false
@@ -26,25 +24,24 @@ function isnodeexpression(e::Expr)
 end
 
 """
-Replaces every subexpression that looks like a node expression with just its
-symbol behind the \$.
+Replaces every subexpression that looks like a node expression with a substitute symbol stored in `exprdict`.
 """
-function replacenodesyms!(exp::Expr)
+function replace_node_expressions!(exp::Expr, exprdict)
     if isnodeexpression(exp)
         error("You can't @lift an expression that only consists of a single node.")
     else
         for (i, arg) in enumerate(exp.args)
             if isnodeexpression(arg)
-                exp.args[i] = nodesym(arg)
+                exp.args[i] = exprdict[arg]
             else
-                replacenodesyms!(arg)
+                replace_node_expressions!(arg, exprdict)
             end
         end
     end
     exp
 end
 
-replacenodesyms!(x) = begin end
+replace_node_expressions!(x, exprdict) = begin end
 
 """
 Replaces an expression with lift(argtuple -> expression, args...), where args
@@ -60,22 +57,34 @@ z = lift((x, y) -> x .+ y, x, y)
 
 ## after
 z = @lift(\$x .+ \$y)
+
+You can also use parentheses around an expression if that expression evaluates to a node.
+
+```julia
+nt = (x = Node(1), y = Node(2))
+@lift($(nt.x) + $(nt.y))
+```
 """
 macro lift(exp)
 
-    nodesyms = findnodesyms(exp)
+    node_expr_set = find_node_expressions(exp)
 
-    if length(nodesyms) == 0
+    if length(node_expr_set) == 0
         error("Did not find any expressions that looked like nodes.")
     end
 
-    replacenodesyms!(exp)
+    # store expressions with their substitute symbols
+    node_expr_arg_dict = Dict(expr => Symbol("arg$i") for (i, expr) in enumerate(node_expr_set))
 
-    # keep an array for ordering because we need this twice
-    nodesyms_array = collect(nodesyms)
+    replace_node_expressions!(exp, node_expr_arg_dict)
+
+    # keep an array for ordering
+    node_expressions_array = collect(keys(node_expr_arg_dict))
+    node_substitutes_array = [node_expr_arg_dict[expr] for expr in node_expressions_array]
+    node_expressions_without_dollar = [n.args[1] for n in node_expressions_array]
 
     # the arguments to the lifted function
-    argtuple = Expr(Symbol(:tuple), nodesyms_array...)
+    argtuple = Expr(Symbol(:tuple), node_substitutes_array...)
 
     # the lifted function itself
     function_expression = Expr(Symbol(:->), argtuple, exp)
@@ -84,8 +93,9 @@ macro lift(exp)
     lift_expression = Expr(
         Symbol(:call),
         Symbol(:lift),
-        esc(function_expression),
-        esc.(nodesyms_array)...
+        function_expression,
+        # the original expressions without dollar signs need to be escaped
+        esc.(node_expressions_without_dollar)...
     )
 
     lift_expression


### PR DESCRIPTION
allows this syntax:

```julia
nt = (x = Node(1), y = Node(2))
z = @lift($(nt.x) * $(nt.y))
```