### PR TITLE
[WIP] clean up recipe / plot signatures

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -525,14 +525,47 @@ end
 # all the plotting functions that get a plot type
 const PlotFunc = Union{Type{Any}, Type{<: AbstractPlot}}
 
-plot(P::PlotFunc, args...; kw_attributes...) = plot!(Scene(), P, Attributes(kw_attributes), args...)
-plot!(P::PlotFunc, args...; kw_attributes...) = plot!(current_scene(), P, Attributes(kw_attributes), args...)
-plot(scene::SceneLike, P::PlotFunc, args...; kw_attributes...) = plot!(Scene(scene), P, Attributes(kw_attributes), args...)
-plot!(scene::SceneLike, P::PlotFunc, args...; kw_attributes...) = plot!(scene, P, Attributes(kw_attributes), args...)
 
-plot(scene::SceneLike, P::PlotFunc, attributes::Attributes, args...; kw_attributes...) = plot!(Scene(scene), P, merge!(Attributes(kw_attributes), attributes), args...)
-plot!(P::PlotFunc, attributes::Attributes, args...; kw_attributes...) = plot!(current_scene(), P, merge!(Attributes(kw_attributes), attributes), args...)
-plot(P::PlotFunc, attributes::Attributes, args...; kw_attributes...) = plot!(Scene(), P, merge!(Attributes(kw_attributes), attributes), args...)
+######################################################################
+# In this section, the plotting functions have P as the first argument
+# These are called from type recipes
+
+# non-mutating, without positional attributes
+
+function plot(P::PlotFunc, args...; kw_attributes...)
+    attributes = Attributes(kw_attributes)
+    plot(P, attributes, args...)
+end
+
+# with positional attributes
+
+function plot(P::PlotFunc, attrs::Attributes, args...; kw_attributes...)
+    attributes = merge!(Attributes(kw_attributes), attrs)
+    scene_attributes = extract_scene_attributes!(attributes)
+    scene = Scene(; scene_attributes...)
+    plot!(scene, P, attributes, args...)
+end
+
+# mutating, without positional attributes
+
+function plot!(P::PlotFunc, scene::SceneLike, args...; kw_attributes...)
+    attributes = Attributes(kw_attributes)
+    plot!(scene, P, attributes, args...)
+end
+
+# without scenelike, use current scene
+
+function plot!(P::PlotFunc, args...; kw_attributes...)
+    plot!(P, current_scene(), args...; kw_attributes...)
+end
+
+# with positional attributes
+
+function plot!(P::PlotFunc, scene::SceneLike, attrs::Attributes, args...; kw_attributes...)
+    attributes = merge!(Attributes(kw_attributes), attrs)
+    plot!(scene, P, attributes, args...)
+end
+######################################################################
 
 
 # plots to scene

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -663,10 +663,10 @@ function extract_scene_attributes!(attributes)
     return result
 end
 
-function plot!(scene::SceneLike, ::Type{PlotType}, attributes::Attributes, input::NTuple{N, Node}, args::Node) where {N, PlotType <: AbstractPlot}
+function plot!(scene::SceneLike, P::PlotFunc, attributes::Attributes, input::NTuple{N, Node}, args::Node) where {N}
     # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
     scene_attributes = extract_scene_attributes!(attributes)
-    plot_object = PlotType(scene, copy(attributes), input, args)
+    plot_object = P(scene, copy(attributes), input, args)
     # transfer the merged attributes from theme and user defined to the scene
     for (k, v) in scene_attributes
         scene.attributes[k] = v
@@ -699,17 +699,18 @@ function plot!(scene::SceneLike, ::Type{PlotType}, attributes::Attributes, input
     scene
 end
 
-function plot!(scene::Combined, ::Type{PlotType}, attributes::Attributes, args...) where PlotType <: AbstractPlot
+
+function plot!(scene::Combined, P::PlotFunc, attributes::Attributes, args...)
     # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
-    plot_object = PlotType(scene, attributes, args)
+    plot_object = P(scene, attributes, args)
     # call user defined recipe overload to fill the plot type
     plot!(plot_object)
     push!(scene.plots, plot_object)
     scene
 end
-function plot!(scene::Combined, ::Type{PlotType}, attributes::Attributes, input::NTuple{N,Node}, args::Node) where {N, PlotType <: AbstractPlot}
+function plot!(scene::Combined, P::PlotFunc, attributes::Attributes, input::NTuple{N,Node}, args::Node) where {N}
     # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
-    plot_object = PlotType(scene, attributes, input, args)
+    plot_object = P(scene, attributes, input, args)
     # call user defined recipe overload to fill the plot type
     plot!(plot_object)
     push!(scene.plots, plot_object)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -534,8 +534,6 @@ plot(scene::SceneLike, P::PlotFunc, attributes::Attributes, args...; kw_attribut
 plot!(P::PlotFunc, attributes::Attributes, args...; kw_attributes...) = plot!(current_scene(), P, merge!(Attributes(kw_attributes), attributes), args...)
 plot(P::PlotFunc, attributes::Attributes, args...; kw_attributes...) = plot!(Scene(), P, merge!(Attributes(kw_attributes), attributes), args...)
 
-# Overload remaining functions
-eval(default_plot_signatures(:plot, :plot!, :Any))
 
 # plots to scene
 

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -567,6 +567,11 @@ function plot!(P::PlotFunc, scene::SceneLike, attrs::Attributes, args...; kw_att
 end
 ######################################################################
 
+# Register plot / plot! using the Any type as PlotType.
+# This is done so that plot(args...) / plot!(args...) can by default go
+# through a pipeline where the appropriate PlotType is determined
+# from the input arguments themselves.
+eval(default_plot_signatures(:plot, :plot!, :Any))
 
 # plots to scene
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -8,33 +8,12 @@ The `Core.@__doc__` macro transfers the docstring given to the Recipe into the f
 """
 function default_plot_signatures(funcname, funcname!, PlotType)
     quote
-
         Core.@__doc__ function ($funcname)(args...; attributes...)
-            attr = Attributes(attributes)
-            kw = extract_scene_attributes!(attr)
-            plot!(Scene(;kw...), $PlotType, attr, args...)
+            plot($PlotType, args...; attributes...)
         end
 
         Core.@__doc__ function ($funcname!)(args...; attributes...)
-            plot!(current_scene(), $PlotType, Attributes(attributes), args...)
-        end
-
-        function ($funcname!)(scene::SceneLike, args...; attributes...)
-            plot!(scene, $PlotType, Attributes(attributes), args...)
-        end
-
-        function ($funcname)(attributes::Attributes, args...; kw_attributes...)
-            merged = merge!(Attributes(kw_attributes), attributes)
-            kw = extract_scene_attributes!(merged)
-            plot!(Scene(;kw...), $PlotType, merged, args...)
-        end
-
-        function ($funcname!)(attributes::Attributes, args...; kw_attributes...)
-            plot!(current_scene(), $PlotType, merge!(Attributes(kw_attributes), attributes), args...)
-        end
-
-        function ($funcname!)(scene::SceneLike, attributes::Attributes, args...; kw_attributes...)
-            plot!(scene, $PlotType, merge!(Attributes(kw_attributes), attributes), args...)
+            plot!($PlotType, args...; attributes...)
         end
     end
 end


### PR DESCRIPTION
I'm trying to remove redundancy, for the recipe signatures, args...; kwargs... should be enough and everything else handled by the backend plot functions. This will probably break some tests if I removed something that's still needed