### PR TITLE
improve slider drag behavior

### DIFF
--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -512,7 +512,7 @@ function default_attributes(::Type{LSlider}, scene)
         "Controls if the parent layout can adjust to this element's height"
         tellheight = true
         "The radius of the slider button."
-        buttonradius = 7f0
+        buttonradius = 9f0
         "The start value of the slider or the value that is closest in the slider range."
         startvalue = 0
         "The current value of the slider."

--- a/src/makielayout/lobjects/lslider.jl
+++ b/src/makielayout/lobjects/lslider.jl
@@ -111,28 +111,19 @@ function LSlider(parent::Scene; bbox = nothing, kwargs...)
 
     bcolor = Node{Any}(buttoncolor_inactive[])
 
+
     button = scatter!(subscene, buttonpoint, markersize = bsize, color = bcolor, marker = '⚫',
         strokewidth = buttonstrokewidth, strokecolor = color_active_dimmed, raw = true)[end]
     decorations[:button] = button
 
-    buttonstate = addmousestate!(subscene, button)
 
-    # on(buttonstate) do state
-    #     typ = typeof(state.typ)
-    #     if typ in (MouseDown, MouseDrag, MouseDragStart, MouseDragStop)
-    #         bcolor[] = color_active[]
-    #     end
-    # end
+    scenestate = addmousestate!(subscene)
 
-    onmouseleftdown(buttonstate) do state
-        bcolor[] = color_active[]
-    end
-
-    onmouseleftup(buttonstate) do state
+    onmouseleftup(scenestate) do state
         bcolor[] = buttoncolor_inactive[]
     end
 
-    onmouseleftdrag(buttonstate) do state
+    onmouseleftdrag(scenestate) do state
 
         pad = buttonradius[] + buttonstrokewidth[]
 
@@ -156,15 +147,15 @@ function LSlider(parent::Scene; bbox = nothing, kwargs...)
         end
     end
 
-    onmouseleftdragstop(buttonstate) do state
+    onmouseleftdragstop(scenestate) do state
         dragging[] = false
         # adjust slider to closest legal value
         sliderfraction[] = sliderfraction[]
     end
 
-    scenestate = addmousestate!(subscene)
+    onmouseleftdown(scenestate) do state
 
-    onmouseleftclick(scenestate) do state
+        bcolor[] = color_active[]
 
         pad = buttonradius[] + buttonstrokewidth[]
 

--- a/src/makielayout/lobjects/lslider.jl
+++ b/src/makielayout/lobjects/lslider.jl
@@ -107,7 +107,7 @@ function LSlider(parent::Scene; bbox = nothing, kwargs...)
 
     linestate = addmousestate!(subscene, linesegs)
 
-    bsize = Node{Float32}(buttonradius[] * 2f0)
+    bsize = @lift($buttonradius * 2f0)
 
     bcolor = Node{Any}(buttoncolor_inactive[])
 


### PR DESCRIPTION
move the button to the place where the first mousedown in the scene happens, so you can start sliding from anywhere. also tie the button color change to mousedown / up of the scene. basically, the button serves no special dragging function anymore, it's just an indicator of the slider position. this should make the slider much more robust and cause fewer glitches