### PR TITLE
better scatter defaults

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -200,13 +200,13 @@ $(ATTRIBUTES)
 @recipe(Scatter, positions) do scene
     Attributes(;
         default_theme(scene)...,
-        color = :black,
+        color = :gray65,
         colormap = :viridis,
         marker = Circle,
-        markersize = 0.1,
+        markersize = 10,
 
-        strokecolor = RGBA(0, 0, 0, 0),
-        strokewidth = 0.0,
+        strokecolor = :black,
+        strokewidth = 1.0,
         glowcolor = RGBA(0, 0, 0, 0),
         glowwidth = 0.0,
 
@@ -215,7 +215,7 @@ $(ATTRIBUTES)
         transform_marker = false, # Applies the plots transformation to marker
         uv_offset_width = Vec4f0(0),
         distancefield = nothing,
-        markerspace = automatic,
+        markerspace = Pixel,
         fxaa = false,
     )
 end


### PR DESCRIPTION
This should provide better defaults for less tweaking with simple plots. The new defaults would have these advantages:

- no squished markers
- reasonable default size
- size not dependent on data scaling (you can't have a good default there, and 0.1 is bad for everything but our examples)
- stroke enabled by default for some robustness against overplotted markers
- gray65 fill for good contrast against light and dark backgrounds and a more elegant look than black

Here's a before just plotting 500 randn() points:

![old](https://user-images.githubusercontent.com/22495855/86795387-ceb29600-c06d-11ea-89dc-a5dfd209cb02.png)

And after:

![new](https://user-images.githubusercontent.com/22495855/86795419-d6723a80-c06d-11ea-99d4-fa70eebcb3df.png)
