### PR TITLE
Improve printing

### DIFF
--- a/src/dictlike.jl
+++ b/src/dictlike.jl
@@ -124,13 +124,32 @@ function setindex!(x::Attributes, value::Node, key::Symbol)
     return x
 end
 
+_indent_attrs(s, n) = join(split(s, '\n'), "\n" * " "^n)
+
 function Base.show(io::IO,::MIME"text/plain", attr::Attributes)
     d = Dict()
-    for p in pairs(attr.attributes)
-        d[p.first] = to_value(p.second)
-    end
-    show(IOContext(io, :limit => false), MIME"text/plain"(), d)
+    print(io, """Attributes with $(length(attr)) $(length(attr) != 1 ? "entries" : "entry")""")
 
+    if length(attr) < 1
+        return
+    end
+
+    print(io, ":")
+
+    ks = sort(collect(keys(attr)), by = lowercase ∘ String)
+    maxlength = maximum(length ∘ String, ks)
+
+    for k in ks
+        print(io, "\n  ")
+        print(io, k)
+        print(io, " => ")
+        v = to_value(attr[k])
+        if v isa Attributes
+            print(io, _indent_attrs(repr(v), 2))
+        else
+            print(io, to_value(attr[k]))
+        end
+    end
 end
 
 Base.show(io::IO, attr::Attributes) = show(io, MIME"text/plain"(), attr)

--- a/src/dictlike.jl
+++ b/src/dictlike.jl
@@ -127,6 +127,9 @@ end
 _indent_attrs(s, n) = join(split(s, '\n'), "\n" * " "^n)
 
 function Base.show(io::IO,::MIME"text/plain", attr::Attributes)
+
+    io = IOContext(io, :compact => true)
+    
     d = Dict()
     print(io, """Attributes with $(length(attr)) $(length(attr) != 1 ? "entries" : "entry")""")
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -152,13 +152,25 @@ end
 
 function Base.show(io::IO, scene::Scene)
     println(io, "Scene ($(size(scene, 1))px, $(size(scene, 2))px):")
-    println(io, "  $(length(scene.plots)) Plot$(_plural_s(scene.plots)):")
-    for (i, plot) in enumerate(scene.plots)
-        println(io, "    $(i == length(scene.plots) ? '└' : '├') ", plot)
+
+    print(io, "  $(length(scene.plots)) Plot$(_plural_s(scene.plots))")
+
+    if length(scene.plots) > 0
+        print(io, ":")
+        for (i, plot) in enumerate(scene.plots)
+            print(io, "\n")
+            print(io, "    $(i == length(scene.plots) ? '└' : '├') ", plot)
+        end
     end
-    println(io, "  $(length(scene.children)) Child Scene$(_plural_s(scene.children)):")
-    for (i, subscene) in enumerate(scene.children)
-        println(io,"    $(i == length(scene.children) ? '└' : '├') Scene ($(size(subscene, 1))px, $(size(subscene, 2))px)")
+
+    print(io, "\n  $(length(scene.children)) Child Scene$(_plural_s(scene.children))")
+    
+    if length(scene.children) > 0
+        print(io, ":")
+        for (i, subscene) in enumerate(scene.children)
+            print(io, "\n")
+            print(io,"    $(i == length(scene.children) ? '└' : '├') Scene ($(size(subscene, 1))px, $(size(subscene, 2))px)")
+        end
     end
 end
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -162,7 +162,7 @@ function Base.show(io::IO, scene::Scene)
     end
 end
 
-_plural_s(x) = length(x) > 1 ? "s" : ""
+_plural_s(x) = length(x) != 1 ? "s" : ""
 
 """
     Stepper(scene, path; format = :jpg)

--- a/src/display.jl
+++ b/src/display.jl
@@ -137,43 +137,32 @@ function backend_show(backend, io::IO, ::MIME"text/plain", scene::Scene)
             end
         end
     end
-    println(io, "Scene ($(size(scene, 1))px, $(size(scene, 2))px):")
-    println(io, "events:")
-    for field in fieldnames(Events)
-        println(io, "    ", field, ": ", to_value(getfield(scene.events, field)))
-    end
-    println(io, "plots:")
-    for plot in scene.plots
-        println(io, "   *", typeof(plot))
-    end
-    print(io, "subscenes:")
-    for subscene in scene.children
-        print(io, "\n   *scene($(size(subscene, 1))px, $(size(subscene, 2))px)")
-    end
+    
+    print(io, scene)
     return
 end
 
 function Base.show(io::IO, plot::Combined)
-    println(io, typeof(plot))
-    println(io, "plots:")
-    for p in plot.plots
-        println(io, "   *", typeof(p))
-    end
-    print(io, "attributes:")
-    for (k, v) in theme(plot)
-        print(io, "\n  $k : $(typeof(to_value(v)))")
-    end
+    print(io, typeof(plot))
 end
 
 function Base.show(io::IO, plot::Atomic)
-    println(io, typeof(plot))
-    print(io, "attributes:")
-    for (k, v) in theme(plot)
-        print(io, "\n  $k : $(typeof(to_value(v)))")
+    print(io, typeof(plot))
+end
+
+function Base.show(io::IO, scene::Scene)
+    println(io, "Scene ($(size(scene, 1))px, $(size(scene, 2))px):")
+    println(io, "  $(length(scene.plots)) Plot$(_plural_s(scene.plots)):")
+    for (i, plot) in enumerate(scene.plots)
+        println(io, "    $(i == length(scene.plots) ? '└' : '├') ", plot)
+    end
+    println(io, "  $(length(scene.children)) Child Scene$(_plural_s(scene.children)):")
+    for (i, subscene) in enumerate(scene.children)
+        println(io,"    $(i == length(scene.children) ? '└' : '├') Scene ($(size(subscene, 1))px, $(size(subscene, 2))px)")
     end
 end
 
-
+_plural_s(x) = length(x) > 1 ? "s" : ""
 
 """
     Stepper(scene, path; format = :jpg)


### PR DESCRIPTION
Fixes the following points:
- plot objects print only their type (nobody wants to see a whole tree of attributes explode when plotting in the REPL)
- attributes don't pretend like they're a Dict when printed but instead have a nicely indented look with nested Attributes now. they also get printed alphabetically and not in random order
- a scene doesn't print its events anymore and is a bit more polished in general