### PR TITLE
Add visible attribute to errorbar

### DIFF
--- a/src/basic_recipes/errorbars.jl
+++ b/src/basic_recipes/errorbars.jl
@@ -3,7 +3,8 @@
         whiskerwidth = 10,
         color = :black,
         linewidth = 1,
-        direction = :y
+        direction = :y,
+        visible = theme(scene, :visible)
     )
 end
 
@@ -29,7 +30,7 @@ f_if(condition, f, arg) = condition ? f(arg) : arg
 
 function _plot_errorbars!(plot, xys, low, high)
 
-    @extract plot (whiskerwidth, color, linewidth, direction)
+    @extract plot (whiskerwidth, color, linewidth, direction, visible)
 
     is_in_y_direction = lift(direction) do dir
         if dir == :y
@@ -65,8 +66,8 @@ function _plot_errorbars!(plot, xys, low, high)
         screen_to_scene([p for pair in screenendpoints_shifted_pairs for p in pair], scene)
     end
 
-    linesegments!(plot, linesegpairs, color = color, linewidth = linewidth)
-    linesegments!(plot, whiskers, color = color, linewidth = linewidth)
+    linesegments!(plot, linesegpairs, color = color, linewidth = linewidth, visible = visible)
+    linesegments!(plot, whiskers, color = color, linewidth = linewidth, visible = visible)
     plot
 end
 


### PR DESCRIPTION
I tried making a figure where you can toggle the visibility of various plots and noticed that `errorbars` don't support `visible` yet. So here's a pr to fix that. Though I wonder if it would make more sense to have `default_theme(scene, LineSegments)` in there instead, similar to how it's done [here](https://github.com/JuliaPlots/AbstractPlotting.jl/blob/4d25c309320953076f78be74e64c70308933c6a3/src/basic_recipes/basic_recipes.jl#L452).