### PR TITLE
add LEditBox

### DIFF
--- a/src/makielayout/MakieLayout.jl
+++ b/src/makielayout/MakieLayout.jl
@@ -60,6 +60,7 @@ include("lobjects/llegend.jl")
 include("lobjects/lobject.jl")
 include("lobjects/lscene.jl")
 include("lobjects/lmenu.jl")
+include("lobjects/leditbox.jl")
 
 export LAxis
 export LSlider
@@ -72,6 +73,7 @@ export LLegend
 export LegendEntry, MarkerElement, PolyElement, LineElement, LegendElement
 export LScene
 export LMenu
+export LEditBox
 export linkxaxes!, linkyaxes!, linkaxes!
 export AxisAspect, DataAspect
 export autolimits!, limits!

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -746,3 +746,121 @@ $(let
 end)
 """
 LScene
+
+
+DEFAULT_KEYBOARD_LAYOUT = let
+    # Key => (base, shift-mod, altgr-mod)
+    Key = AbstractPlotting.Keyboard
+
+    Dict(
+        Key.q => ('q', 'Q'),
+        Key.w => ('w', 'W'),
+        Key.e => ('e', 'E'),
+        Key.r => ('r', 'R'),
+        Key.t => ('t', 'T'),
+        Key.z => ('z', 'Z'),
+        Key.u => ('u', 'U'),
+        Key.i => ('i', 'I'),
+        Key.o => ('o', 'O'),
+        Key.p => ('p', 'P'),
+        Key.a => ('a', 'A'),
+        Key.s => ('s', 'S'),
+        Key.d => ('d', 'D'),
+        Key.f => ('f', 'F'),
+        Key.g => ('g', 'G'),
+        Key.h => ('h', 'H'),
+        Key.j => ('j', 'J'),
+        Key.k => ('k', 'K'),
+        Key.l => ('l', 'L'),
+        Key.y => ('y', 'Y'),
+        Key.x => ('x', 'X'),
+        Key.c => ('c', 'C'),
+        Key.v => ('v', 'V'),
+        Key.b => ('b', 'B'),
+        Key.n => ('n', 'N'),
+        Key.m => ('m', 'M'),
+        Key.grave_accent => ('`', '~', '`'),
+        Key._1 => ('1', '!', '¹'), # Technically ¹²³ should not be here
+        Key._2 => ('2', '@', '²'),
+        Key._3 => ('3', '#', '³'),
+        Key._4 => ('4', '$'),
+        Key._5 => ('5', '%'),
+        Key._6 => ('6', '^'),
+        Key._7 => ('7', '&'),
+        Key._8 => ('8', '*'),
+        Key._9 => ('9', '('),
+        Key._0 => ('0', ')'),
+        Key.minus => ('-', '_', '-'),
+        Key.equal => ('=', '+'),
+        Key.left_bracket => ('[', '{'),
+        Key.right_bracket => (']', '}'),
+        Key.semicolon => (';', ':'),
+        Key.apostrophe => ('\'', '"'),
+        Key.backslash => ('\\', '|'),
+        Key.comma => (',', '<'),
+        Key.period => ('.', '>'),
+        Key.slash => ('/', '?'),
+        Key.space => (' ')
+    )
+end
+
+function default_attributes(::Type{LEditBox}, scene)
+    attrs, docdict, defaultdict = @documented_attributes begin
+        "The horizontal alignment of the edit box in its suggested boundingbox"
+        halign = :center
+        "The vertical alignment of the edit box in its suggested boundingbox"
+        valign = :center
+        "The extra space added to the sides of the edit box text's boundingbox."
+        padding = (10f0, 10f0, 10f0, 10f0)
+        "The font size of the edit box text."
+        textsize = lift_parent_attribute(scene, :fontsize, 20f0)
+        "The text of the edit box."
+        text = "EditBox"
+        "The font family of the edit box."
+        font = lift_parent_attribute(scene, :font, "DejaVu Sans")
+        "The width setting of the edit box."
+        width = Auto()
+        "The height setting of the edit box."
+        height = Auto()
+        "Controls if the parent layout can adjust to this element's width"
+        tellwidth = true
+        "Controls if the parent layout can adjust to this element's height"
+        tellheight = true
+        "The line width of the edit box border."
+        strokewidth = 5f0
+        "The color of the edit box border."
+        strokecolor = RGBf0(0.7, 0.7, 0.7)
+        "The color of the border when the mouse hovers over the edit box."
+        strokecolor_hover = RGBf0(0.4, 0.4, 0.4)
+        "The color of the border when the edit box is focused."
+        strokecolor_active = :black
+        "The color of the edit box."
+        boxcolor = :white
+        "The color of the text."
+        textcolor = :black
+        "The color of the text when the mouse hovers over the edit box."
+        textcolor_hover = :black
+        "The color of the text when the edit box is focused."
+        textcolor_active = :black
+        "The color of the edit box when it is focused."
+        boxcolor_active = :white
+        "The color of the edit box when the mouse hovers over the edit box."
+        boxcolor_hover = :white
+        "The align mode of the edit box in its parent GridLayout."
+        alignmode = Inside()
+        "Is the edit box currently focused?"
+        focused = false
+        "A dictionary mapping keys to characters. Each element may contain `(normal, shift-mod, alt-mod)` characters."
+        keyboard_layout = DEFAULT_KEYBOARD_LAYOUT
+    end
+    (attributes = attrs, documentation = docdict, defaults = defaultdict)
+end
+
+@doc """
+LEditBox has the following attributes:
+$(let
+    _, docs, defaults = default_attributes(LEditBox, nothing)
+    docvarstring(docs, defaults)
+end)
+"""
+LEditBox

--- a/src/makielayout/lobjects/leditbox.jl
+++ b/src/makielayout/lobjects/leditbox.jl
@@ -1,0 +1,155 @@
+function LEditBox(scene::Scene; bbox = nothing, kwargs...)
+
+    default_attrs = default_attributes(LEditBox, scene).attributes
+    theme_attrs = subtheme(scene, :LEditBox)
+    attrs = merge!(merge!(Attributes(kwargs), theme_attrs), default_attrs)
+
+    @extract attrs (padding, textsize, text, font, halign, valign, strokewidth,
+        strokecolor, strokecolor_hover, strokecolor_active,
+        boxcolor, boxcolor_hover, boxcolor_active,
+        textcolor, textcolor_hover, textcolor_active,
+        focused, keyboard_layout
+    )
+
+    decorations = Dict{Symbol, Any}()
+
+    layoutobservables = LayoutObservables(
+        LEditBox, attrs.width, attrs.height, attrs.tellwidth, attrs.tellheight,
+        halign, valign, attrs.alignmode; suggestedbbox = bbox
+    )
+
+    textpos = Node(Point2f0(0, 0))
+    subarea = lift(bbox -> IRect2D(bbox), layoutobservables.computedbbox)
+    subscene = Scene(scene, subarea, camera=campixel!)
+
+    boxrect = lift(layoutobservables.computedbbox) do bbox
+        BBox(0, width(bbox), 0, height(bbox))
+    end
+
+    on(boxrect) do rect
+        textpos[] = Point2f0(
+            left(rect) + 0.5f0 * width(rect),
+            bottom(rect) + 0.5f0 * height(rect)
+        )
+    end
+
+    bcolor = Node{Any}(boxcolor[])
+    scolor = Node{Any}(strokecolor[])
+    # One line doesn't show up :(
+    # box = poly!(
+    #     subscene, boxrect, strokewidth = strokewidth, strokecolor = scolor,
+    #     color = bcolor, raw = true
+    # )[end]
+    box = mesh!(subscene, boxrect, color = bcolor, raw = true, shading=false)[end]
+    outline = wireframe!(subscene, boxrect, linewidth = strokewidth, color = scolor, raw = true)[end]
+    decorations[:box] = box
+
+
+
+    lcolor = Node{Any}(textcolor[])
+    proxy_text = map(t -> isempty(t) ? " " : t, text)
+    labeltext = text!(
+        subscene, proxy_text, position = textpos, textsize = textsize,
+        font = font, color = lcolor, align = (:center, :center), raw = true
+    )[end]
+
+    # move text in front of background to be sure it's not occluded
+    translate!(labeltext, 0, 0, 1)
+
+
+    onany(text, textsize, font, padding) do text, textsize, font, padding
+        textbb = FRect2D(boundingbox(labeltext))
+        autowidth = width(textbb) + padding[1] + padding[2]
+        autoheight = height(textbb) + padding[3] + padding[4]
+        layoutobservables.autosize[] = (autowidth, autoheight)
+    end
+
+
+
+    mousestate = addmousestate!(scene, box, labeltext, outline)
+
+    onmouseover(mousestate) do state
+        if !focused[]
+            bcolor[] = boxcolor_hover[]
+            lcolor[] = textcolor_hover[]
+            scolor[] = strokecolor_hover[]
+        end
+    end
+
+    onmouseout(mousestate) do state
+        if !focused[]
+            bcolor[] = boxcolor[]
+            lcolor[] = textcolor[]
+            scolor[] = strokecolor[]
+        end
+    end
+
+    on(focused) do focused
+        if focused
+            bcolor[] = boxcolor_active[]
+            lcolor[] = textcolor_active[]
+            scolor[] = strokecolor_active[]
+        else
+            bcolor[] = boxcolor[]
+            lcolor[] = textcolor[]
+            scolor[] = strokecolor[]
+        end
+    end
+
+    # TODO: Is there a better way to do this?
+    on(AbstractPlotting.root(scene).events.mousebuttons) do buttons
+        if Mouse.left in buttons
+            if mouseover(scene, box, labeltext)
+                focused[] || (focused[] = true)
+            else
+                focused[] && (focused[] = false)
+            end
+        end
+    end
+
+    on(AbstractPlotting.root(scene).events.keyboardbuttons) do _keys
+        focused[] || return
+        isempty(_keys) && return
+
+        if Keyboard.enter in _keys
+            focused[] = false
+            return
+        end
+
+        # TODO Should this return?
+        if Keyboard.backspace in _keys
+            text[] = chop(text[])
+            return
+        end
+
+        # TODO shift + alt => modifier = 4?
+        # This would probably require some fallback system...
+        # e.g. if shift+alt is undefined, do shift
+        modifier = 1    # None
+        if Keyboard.left_shift in _keys;  modifier = 2 end
+        if Keyboard.right_shift in _keys; modifier = 2 end
+        if Keyboard.right_alt in _keys;   modifier = 3 end
+
+        characters = Char[]
+        for key in _keys
+            if key in keys(keyboard_layout[])
+                try
+                    chars = keyboard_layout[][key]
+                    push!(characters, chars[modifier <= end ? modifier : 1])
+                catch e
+                    @warn "Failed to process $key in LEditBox\n" exception=e
+                end
+            end
+        end
+
+        isempty(characters) && return
+        text[] = text[] * join(characters)
+    end
+
+
+    text[] = text[]
+    # trigger bbox
+    layoutobservables.suggestedbbox[] = layoutobservables.suggestedbbox[]
+
+    LEditBox(scene, layoutobservables, attrs, decorations)
+end

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -145,3 +145,10 @@ struct LScene <: AbstractPlotting.AbstractScene
     attributes::Attributes
     layoutobservables::MakieLayout.LayoutObservables
 end
+
+struct LEditBox <: LObject
+    parent::Scene
+    layoutobservables::LayoutObservables
+    attributes::Attributes
+    decorations::Dict{Symbol, Any}
+end


### PR DESCRIPTION
I tried making an edit box. The basic functionality works - it displays text, you can select it by clicking on it, type and remove text and deselect it by pressing enter or clicking elsewhere. You can also pass a custom keyboard layout if you want.

Some issues this implementation has:
* Keyboard layouts are rather cumbersome and ignore the system language.
* The keyboard layout is probably incomplete
* You cannot mouse drag select text. 
* There is no cursor. (It can't be moved, it isn't displayed and sorta as a result you cannot use the delete key)
* No ctrl + a, c, v, etc
* No shift+alt modifier (though that'd be rather easy to add)
* Typing in the edit box doesn't "consume" events, so you may trigger other events in the scene while typing.
* Text overflows in both directions, rather than just towards the left. So if you type a lot you won't see the most recently typed characters
* If you press a second key before releasing the first you'll get ghost inputs. I.e. `a down, b down, a up, b up` generates "abab" and `a down, b down, b up, a up` generates "abaa" when both should be "ab".

For most of these issues I either don't know how to solve them or I think they're low priority. Maybe someone else can take a stab at it or we can leave them later?