### PR TITLE
fix delete_scene

### DIFF
--- a/src/makielayout/helpers.jl
+++ b/src/makielayout/helpers.jl
@@ -338,7 +338,7 @@ function remove_element(::Nothing)
 end
 
 function delete_scene!(s::Scene)
-    for p in s.plots
+    for p in copy(s.plots)
         delete!(s, p)
     end
     deleteat!(s.parent.children, findfirst(x -> x === s, s.parent.children))


### PR DESCRIPTION
I think what's going on is that `scene.plots` is getting changed in place during the iteration, so the iterator will think it has finished when it has not. For example, if `length(scene.plots) == 2`, after cleaning up the first, it will see that the length of the array equals the number of times it has iterated, so it will stop. I imagine the shallow copy is not a performance problem, otherwise one can use some smart while loop I guess, but I'd prefer to keep it simple.