### PR TITLE
add LTextbox

### DIFF
--- a/src/makielayout/MakieLayout.jl
+++ b/src/makielayout/MakieLayout.jl
@@ -61,6 +61,7 @@ include("lobjects/llegend.jl")
 include("lobjects/lobject.jl")
 include("lobjects/lscene.jl")
 include("lobjects/lmenu.jl")
+include("lobjects/ltextbox.jl")
 
 export LAxis
 export LSlider
@@ -73,6 +74,7 @@ export LLegend
 export LegendEntry, MarkerElement, PolyElement, LineElement, LegendElement
 export LScene
 export LMenu
+export LTextbox
 export linkxaxes!, linkyaxes!, linkaxes!
 export AxisAspect, DataAspect
 export autolimits!, limits!

--- a/src/makielayout/MakieLayout.jl
+++ b/src/makielayout/MakieLayout.jl
@@ -14,6 +14,7 @@ import Animations
 import PlotUtils
 using GridLayoutBase
 import Showoff
+using Colors
 
 const FPS = Node(30)
 const COLOR_ACCENT = Ref(RGBf0(((79, 122, 214) ./ 255)...))

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -806,7 +806,7 @@ function default_attributes(::Type{LTextbox}, scene)
         cornerradius = 8
         "Corner segments of one rounded corner."
         cornersegments = 20
-        "Validator that is called with validate_textbox(string, validator) to determine if the current string is valid. Can by default be a RegEx that needs to match the complete string, or a function taking a string as input and returning a Bool."
+        "Validator that is called with validate_textbox(string, validator) to determine if the current string is valid. Can by default be a RegEx that needs to match the complete string, or a function taking a string as input and returning a Bool. If the validator is a type T (for example Float64), validation will be `tryparse(string, T)`."
         validator = str -> true
         "Restricts the allowed unicode input via is_allowed(char, restriction)."
         restriction = nothing

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -746,3 +746,82 @@ $(let
 end)
 """
 LScene
+
+
+
+
+function default_attributes(::Type{LTextbox}, scene)
+    attrs, docdict, defaultdict = @documented_attributes begin
+        "The height setting of the textbox."
+        height = Auto()
+        "The width setting of the textbox."
+        width = Auto()
+        "Controls if the parent layout can adjust to this element's width."
+        tellwidth = true
+        "Controls if the parent layout can adjust to this element's height."
+        tellheight = true
+        "The horizontal alignment of the textbox in its suggested bounding box."
+        halign = :center
+        "The vertical alignment of the textbox in its suggested bounding box."
+        valign = :center
+        "The alignment of the textbox in its suggested bounding box."
+        alignmode = Inside()
+        "A placeholder text that is displayed when the saved string is nothing."
+        placeholder = "Click to edit..."
+        "The currently saved string."
+        content = nothing
+        "The currently displayed string (for internal use)."
+        displayed_string = nothing
+        "Text size."
+        textsize = lift_parent_attribute(scene, :fontsize, 20f0)
+        "Text color."
+        textcolor = :black
+        "Text color for the placeholder."
+        textcolor_placeholder = RGBf0(0.5, 0.5, 0.5)
+        "Font family."
+        font = lift_parent_attribute(scene, :font, "DejaVu Sans")
+        "Color of the box."
+        boxcolor = :transparent
+        "Color of the box when focused."
+        boxcolor_focused = :transparent
+        "Color of the box when focused."
+        boxcolor_focused_invalid = RGBAf0(1, 0, 0, 0.3)
+        "Color of the box when hovered."
+        boxcolor_hover = :transparent
+        "Color of the box border."
+        bordercolor = RGBf0(0.80, 0.80, 0.80)
+        "Color of the box border when hovered."
+        bordercolor_hover = COLOR_ACCENT_DIMMED[]
+        "Color of the box border when focused."
+        bordercolor_focused = COLOR_ACCENT[]
+        "Color of the box border when focused and invalid."
+        bordercolor_focused_invalid = RGBf0(1, 0, 0)
+        "Width of the box border."
+        borderwidth = 2f0
+        "Padding of the text against the box."
+        textpadding = (10, 10, 10, 10)
+        "If the textbox is focused and receives text input."
+        focused = false
+        "Corner radius of text box."
+        cornerradius = 8
+        "Corner segments of one rounded corner."
+        cornersegments = 20
+        "Validator that is called with validate_textbox(string, validator) to determine if the current string is valid. Can by default be a RegEx that needs to match the complete string, or a function taking a string as input and returning a Bool."
+        validator = str -> true
+        "Restricts the allowed unicode input via is_allowed(char, restriction)."
+        restriction = nothing
+        "The color of the cursor."
+        cursorcolor = :transparent
+    end
+    (attributes = attrs, documentation = docdict, defaults = defaultdict)
+end
+
+@doc """
+    LTextbox(parent::Scene; bbox = nothing, kwargs...)
+LTextbox has the following attributes:
+$(let
+    _, docs, defaults = default_attributes(LTextbox, nothing)
+    docvarstring(docs, defaults)
+end)
+"""
+LTextbox

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -768,8 +768,8 @@ function default_attributes(::Type{LTextbox}, scene)
         alignmode = Inside()
         "A placeholder text that is displayed when the saved string is nothing."
         placeholder = "Click to edit..."
-        "The currently saved string."
-        content = nothing
+        "The currently stored string."
+        stored_string = nothing
         "The currently displayed string (for internal use)."
         displayed_string = nothing
         "Text size."

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -772,6 +772,10 @@ function default_attributes(::Type{LTextbox}, scene)
         stored_string = nothing
         "The currently displayed string (for internal use)."
         displayed_string = nothing
+        "Controls if the displayed text is reset to the stored text when defocusing the textbox without submitting."
+        reset_on_defocus = false
+        "Controls if the textbox is defocused when a string is submitted."
+        defocus_on_submit = true
         "Text size."
         textsize = lift_parent_attribute(scene, :fontsize, 20f0)
         "Text color."

--- a/src/makielayout/geometrybasics_extension.jl
+++ b/src/makielayout/geometrybasics_extension.jl
@@ -9,10 +9,10 @@ topleft(bbox::Rect2D) = Point(left(bbox), top(bbox))
 bottomright(bbox::Rect2D) = Point(right(bbox), bottom(bbox))
 topright(bbox::Rect2D) = Point(right(bbox), top(bbox))
 
-topline(bbox::FRect2D) = (topleft(bbox), topright(bbox))
-bottomline(bbox::FRect2D) = (bottomleft(bbox), bottomright(bbox))
-leftline(bbox::FRect2D) = (bottomleft(bbox), topleft(bbox))
-rightline(bbox::FRect2D) = (bottomright(bbox), topright(bbox))
+topline(bbox::Rect2D) = (topleft(bbox), topright(bbox))
+bottomline(bbox::Rect2D) = (bottomleft(bbox), bottomright(bbox))
+leftline(bbox::Rect2D) = (bottomleft(bbox), topleft(bbox))
+rightline(bbox::Rect2D) = (bottomright(bbox), topright(bbox))
 
 function shrinkbymargin(rect, margin)
     return IRect(minimum(rect) .+ margin, (widths(rect) .- 2 .* margin))
@@ -30,12 +30,12 @@ end
 xlimits(r::Rect) = limits(r, 1)
 ylimits(r::Rect) = limits(r, 2)
 
-function enlarge(bbox::FRect2D, l, r, b, t)
+function enlarge(bbox::Rect2D, l, r, b, t)
     BBox(left(bbox) - l, right(bbox) + r, bottom(bbox) - b, top(bbox) + t)
 end
 
-function center(bbox::FRect2D)
-    Point2f0((right(bbox) + left(bbox)) / 2, (top(bbox) + bottom(bbox)) / 2)
+function center(bbox::Rect2D)
+    Point2((right(bbox) + left(bbox)) / 2, (top(bbox) + bottom(bbox)) / 2)
 end
 
 """

--- a/src/makielayout/lobjects/lmenu.jl
+++ b/src/makielayout/lobjects/lmenu.jl
@@ -257,7 +257,7 @@ function LMenu(parent::Scene; bbox = nothing, kwargs...)
     end
 
     # close the menu if the user clicks somewhere else
-    onmouseupoutside(addmousestate!(scene)) do state
+    onmousedownoutside(addmousestate!(scene)) do state
         if is_open[]
             is_open[] = !is_open[]
         end

--- a/src/makielayout/lobjects/ltextbox.jl
+++ b/src/makielayout/lobjects/ltextbox.jl
@@ -1,0 +1,355 @@
+function LTextbox(parent::Scene; bbox = nothing, kwargs...)
+
+    attrs = merge!(
+        Attributes(kwargs),
+        default_attributes(LTextbox, parent).attributes)
+
+    @extract attrs (halign, valign, textsize, content, placeholder,
+        textcolor, textcolor_placeholder, displayed_string,
+        boxcolor, boxcolor_focused_invalid, boxcolor_focused, boxcolor_hover,
+        bordercolor, textpadding, bordercolor_focused, bordercolor_hover, focused,
+        bordercolor_focused_invalid,
+        borderwidth, cornerradius, cornersegments, boxcolor_focused,
+        validator, restriction, cursorcolor)
+
+    decorations = Dict{Symbol, Any}()
+
+    layoutobservables = LayoutObservables(LTextbox, attrs.width, attrs.height,
+        attrs.tellwidth, attrs.tellheight,
+        halign, valign, attrs.alignmode; suggestedbbox = bbox)
+
+    scenearea = lift(layoutobservables.computedbbox) do bb
+        Rect(round.(Int, bb.origin), round.(Int, bb.widths))
+    end
+
+    scene = Scene(parent, scenearea, raw = true, camera = campixel!)
+
+    cursorindex = Node(0)
+    ltextbox = LTextbox(scene, attrs, layoutobservables, decorations, cursorindex, nothing)
+
+
+
+    bbox = lift(FRect2D ∘ AbstractPlotting.zero_origin, scenearea)
+
+    roundedrectpoints = lift(roundedrectvertices, scenearea, cornerradius, cornersegments)
+
+    displayed_string[] = isnothing(content[]) ? placeholder[] : content[]
+
+    content_is_valid = lift(displayed_string, validator) do str, validator
+        valid::Bool = validate_textbox(str, validator)
+    end
+
+    hovering = Node(false)
+
+    realbordercolor = lift(bordercolor, bordercolor_focused,
+        bordercolor_focused_invalid, bordercolor_hover, focused, content_is_valid, hovering,
+        typ = Any) do bc, bcf, bcfi, bch, focused, valid, hovering
+
+        if focused
+            valid ? bcf : bcfi
+        else
+            hovering ? bch : bc
+        end
+    end
+
+    realboxcolor = lift(boxcolor, boxcolor_focused,
+        boxcolor_focused_invalid, boxcolor_hover, focused, content_is_valid, hovering,
+        typ = Any) do bc, bcf, bcfi, bch, focused, valid, hovering
+
+        if focused
+            valid ? bcf : bcfi
+        else
+            hovering ? bch : bc
+        end
+    end
+
+    box = poly!(parent, roundedrectpoints, strokewidth = borderwidth,
+        strokecolor = realbordercolor,
+        color = realboxcolor, raw = true)[end]
+
+    displayed_chars = @lift([c for c in $displayed_string])
+
+    realtextcolor = lift(textcolor, textcolor_placeholder, focused, content, typ = Any) do tc, tcph, foc, cont
+        if !foc && isnothing(cont)
+            tcph
+        else
+            tc
+        end
+    end
+
+    t = LText(scene, text = displayed_string, bbox = bbox, halign = :left, valign = :top,
+        width = Auto(true), height = Auto(true), color = realtextcolor,
+        textsize = textsize, padding = textpadding)
+
+    displayed_charbbs = lift(t.layoutobservables.reportedsize) do sz
+        charbbs(t.textobject)
+    end
+
+    cursorpoints = lift(cursorindex, displayed_charbbs) do ci, bbs
+
+        if (ci) > length(bbs)
+            # correct cursorindex if it's outside of the displayed charbbs range
+            cursorindex[] = length(bbs)
+            return
+        end
+
+        if ci == 0
+            [leftline(bbs[1])...]
+        else
+            [rightline(bbs[ci])...]
+        end
+    end
+
+    cursor = linesegments!(scene, cursorpoints, color = cursorcolor, linewidth = 2)[end]
+
+    cursoranimtask = nothing
+
+    on(t.layoutobservables.reportedsize) do sz
+        layoutobservables.autosize[] = sz
+    end
+
+    # trigger text for autosize
+    t.text = displayed_string[]
+
+    # trigger bbox
+    layoutobservables.suggestedbbox[] = layoutobservables.suggestedbbox[]
+
+    mousestate = addmousestate!(scene)
+
+    onmouseleftclick(mousestate) do state
+        focus!(ltextbox)
+
+        if isnothing(content[])
+            # there isn't text to select yet, only placeholder
+            return
+        end
+
+        pos = state.pos
+        closest_charindex = argmin(
+            [sum((pos .- center(bb)).^2) for bb in displayed_charbbs[]]
+        )
+        # set cursor to index of closest char if right of center, or previous char if left of center
+        cursorindex[] = if (pos .- center(displayed_charbbs[][closest_charindex]))[1] > 0
+            closest_charindex
+        else
+            closest_charindex - 1
+        end
+    end
+
+    onmouseover(mousestate) do state
+        hovering[] = true
+    end
+
+    onmouseout(mousestate) do state
+        hovering[] = false
+    end
+
+    onmousedownoutside(mousestate) do state
+        abort()
+    end
+
+    function insertchar!(c, index)
+        if displayed_chars[] == [' ']
+            empty!(displayed_chars[])
+            index = 1
+        end
+        newchars = [displayed_chars[][1:index-1]; c; displayed_chars[][index:end]]
+        displayed_string[] = join(newchars)
+        cursorindex[] = index
+    end
+
+    function appendchar!(c)
+        insertchar!(c, length(displayed_string[]))
+    end
+
+    function removechar!(index)
+        newchars = [displayed_chars[][1:index-1]; displayed_chars[][index+1:end]]
+
+        if isempty(newchars)
+            newchars = [' ']
+        end
+
+        if cursorindex[] >= index
+            cursorindex[] = max(0, cursorindex[] - 1)
+        end
+
+        displayed_string[] = join(newchars)
+    end
+
+    on(events(scene).unicode_input) do char_array
+        if !focused[] || isempty(char_array)
+            return
+        end
+
+        for c in char_array
+            if is_allowed(c, restriction[])
+                insertchar!(c, cursorindex[] + 1)
+            end
+        end
+    end
+
+
+    function submit()
+        if content_is_valid[]
+            defocus!(ltextbox)
+            content[] = displayed_string[]
+        end
+    end
+
+    function abort()
+        cursorindex[] = 0
+        if isnothing(content[])
+            displayed_string[] = placeholder[]
+        else
+            displayed_string[] = content[]
+        end
+        defocus!(ltextbox)
+    end
+
+    function cursor_forward()
+        cursorindex[] = min(length(displayed_string[]), cursorindex[] + 1)
+    end
+
+    function cursor_backward()
+        cursorindex[] = max(0, cursorindex[] - 1)
+    end
+
+
+    on(events(scene).keyboardbuttons) do button_set
+        if !focused[] || isempty(button_set)
+            return
+        end
+
+        for key in button_set
+            if key == Keyboard.backspace
+                removechar!(cursorindex[])
+            elseif key == Keyboard.delete
+                removechar!(cursorindex[] + 1)
+            elseif key == Keyboard.enter
+                submit()
+            elseif key == Keyboard.escape
+                abort()
+            elseif key == Keyboard.right
+                cursor_forward()
+            elseif key == Keyboard.left
+                cursor_backward()
+            end
+        end
+    end
+
+    ltextbox
+end
+
+
+function charbbs(text)
+    positions = AbstractPlotting.layout_text(text[1][], text.position[], text.textsize[],
+        text.font[], text.align[], text.rotation[], text.model[],
+        text.justification[], text.lineheight[])
+
+    font = AbstractPlotting.to_font(text.font[])
+
+    bbs = [
+        AbstractPlotting.FreeTypeAbstraction.height_insensitive_boundingbox(
+            AbstractPlotting.FreeTypeAbstraction.get_extent(font, char),
+            font
+        )
+        for char in text[1][]
+    ]
+
+    bbs_shifted_scaled = [Rect2D(
+            (AbstractPlotting.origin(bb) .* text.textsize[] .+ pos[1:2])...,
+            (widths(bb) .* text.textsize[])...)
+        for (bb, pos) in zip(bbs, positions)]
+end
+
+function validate_textbox(str, validator::Function)
+    validator(str)
+end
+
+function validate_textbox(str, T::Type)
+    !isnothing(tryparse(T, str))
+end
+
+function validate_textbox(str, validator::Regex)
+    m = match(validator, str)
+    # check that the validator matches the whole string
+    !isnothing(m) && m.match == str
+end
+
+function is_allowed(char, restriction::Nothing)
+    true
+end
+
+function is_allowed(char, restriction::Function)
+    allowed::Bool = restriction(char)
+end
+
+"""
+    reset!(tb::LTextbox)
+Resets the content of the given `LTextbox` to `nothing` without triggering listeners, and resets the `LTextbox` to the `placeholder` text.
+"""
+function reset!(tb::LTextbox)
+    tb.content.val = nothing
+    tb.displayed_string = tb.placeholder[]
+    defocus!(tb)
+    nothing
+end
+
+"""
+    set!(tb::LTextbox, string::String)
+Sets the content of the given `LTextbox` to `string`, triggering listeners of `tb.content`.
+"""
+function set!(tb::LTextbox, string::String)
+    if !validate_textbox(string, tb.validator[])
+        error("Invalid string \"$(string)\" for textbox.")
+    end
+
+    tb.displayed_string = string
+    tb.content = string
+    nothing
+end
+
+"""
+    focus!(tb::LTextbox)
+Focuses an `LTextbox` and makes it ready to receive keyboard input.
+"""
+function focus!(tb::LTextbox)
+    if !tb.focused[]
+        if isnothing(tb.content[])
+            tb.cursorindex[] = 1
+            tb.displayed_string = " "
+        end
+        tb.focused = true
+
+        cursoranim = Animations.Loop(
+            Animations.Animation(
+                [0, 1.0],
+                [Colors.alphacolor(COLOR_ACCENT[], 0), Colors.alphacolor(COLOR_ACCENT[], 1)],
+                Animations.sineio(n = 2, yoyo = true, postwait = 0.2)),
+                0.0, 0.0, 1000)
+
+        if !isnothing(tb.cursoranimtask)
+            Animations.stop(tb.cursoranimtask)
+            tb.cursoranimtask = nothing
+        end
+
+        tb.cursoranimtask = Animations.animate_async(cursoranim; fps = 30) do t, color
+            tb.cursorcolor = color
+        end
+    end
+    nothing
+end
+
+"""
+    defocus!(tb::LTextbox)
+Defocuses an `LTextbox` so it doesn't receive keyboard input.
+"""
+function defocus!(tb::LTextbox)
+    if !isnothing(tb.cursoranimtask)
+        Animations.stop(tb.cursoranimtask)
+        tb.cursoranimtask = nothing
+    end
+    tb.cursorcolor = :transparent
+    tb.focused = false
+    nothing
+end

--- a/src/makielayout/lobjects/ltextbox.jl
+++ b/src/makielayout/lobjects/ltextbox.jl
@@ -35,14 +35,14 @@ function LTextbox(parent::Scene; bbox = nothing, kwargs...)
 
     displayed_string[] = isnothing(content[]) ? placeholder[] : content[]
 
-    content_is_valid = lift(displayed_string, validator) do str, validator
+    displayed_is_valid = lift(displayed_string, validator) do str, validator
         valid::Bool = validate_textbox(str, validator)
     end
 
     hovering = Node(false)
 
     realbordercolor = lift(bordercolor, bordercolor_focused,
-        bordercolor_focused_invalid, bordercolor_hover, focused, content_is_valid, hovering,
+        bordercolor_focused_invalid, bordercolor_hover, focused, displayed_is_valid, hovering,
         typ = Any) do bc, bcf, bcfi, bch, focused, valid, hovering
 
         if focused
@@ -53,7 +53,7 @@ function LTextbox(parent::Scene; bbox = nothing, kwargs...)
     end
 
     realboxcolor = lift(boxcolor, boxcolor_focused,
-        boxcolor_focused_invalid, boxcolor_hover, focused, content_is_valid, hovering,
+        boxcolor_focused_invalid, boxcolor_hover, focused, displayed_is_valid, hovering,
         typ = Any) do bc, bcf, bcfi, bch, focused, valid, hovering
 
         if focused
@@ -191,7 +191,7 @@ function LTextbox(parent::Scene; bbox = nothing, kwargs...)
 
 
     function submit()
-        if content_is_valid[]
+        if displayed_is_valid[]
             defocus!(ltextbox)
             content[] = displayed_string[]
         end

--- a/src/makielayout/lobjects/ltextbox.jl
+++ b/src/makielayout/lobjects/ltextbox.jl
@@ -66,6 +66,7 @@ function LTextbox(parent::Scene; bbox = nothing, kwargs...)
     box = poly!(parent, roundedrectpoints, strokewidth = borderwidth,
         strokecolor = realbordercolor,
         color = realboxcolor, raw = true)[end]
+    decorations[:box] = box
 
     displayed_chars = @lift([c for c in $displayed_string])
 

--- a/src/makielayout/mousestatemachine.jl
+++ b/src/makielayout/mousestatemachine.jl
@@ -27,7 +27,7 @@ mousestates = (:MouseOut, :MouseEnter, :MouseOver,
     :MouseLeftDragStop, :MouseRightDragStop, :MouseMiddleDragStop,
     :MouseLeftClick, :MouseRightClick, :MouseMiddleClick,
     :MouseLeftDoubleclick, :MouseRightDoubleclick, :MouseMiddleDoubleclick,
-    :MouseUpOutside
+    :MouseUpOutside, :MouseDownOutside
     )
 
 for statetype in mousestates

--- a/src/makielayout/mousestatemachine.jl
+++ b/src/makielayout/mousestatemachine.jl
@@ -27,7 +27,7 @@ mousestates = (:MouseOut, :MouseEnter, :MouseOver,
     :MouseLeftDragStop, :MouseRightDragStop, :MouseMiddleDragStop,
     :MouseLeftClick, :MouseRightClick, :MouseMiddleClick,
     :MouseLeftDoubleclick, :MouseRightDoubleclick, :MouseMiddleDoubleclick,
-    :MouseUpOutside, :MouseDownOutside
+    :MouseDownOutside
     )
 
 for statetype in mousestates
@@ -184,7 +184,7 @@ function addmousestate!(scene, elements...)
                     mouse_downed_inside[] = true
                 else
                     mouse_downed_inside[] = false
-                    # mousestate[] = MouseDownedOutside()
+                    mousestate[] = MouseState(MouseDownOutside(), t, pos, tprev[], prev[])
                 end
             end
         elseif mousedrag == Mouse.up

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -145,3 +145,12 @@ struct LScene <: AbstractPlotting.AbstractScene
     attributes::Attributes
     layoutobservables::MakieLayout.LayoutObservables
 end
+
+mutable struct LTextbox <: LObject
+    scene::Scene
+    attributes::Attributes
+    layoutobservables::GridLayoutBase.LayoutObservables
+    decorations::Dict{Symbol, Any}
+    cursorindex::Node{Int}
+    cursoranimtask
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ using MeshIO, FileIO, AbstractPlotting.MakieLayout
     to = gl2[1, 4] = LToggle(scene)
     te = layout[0, :] = LText(scene, "A super title")
     me = layout[end+1, :] = LMenu(scene, options = ["one", "two", "three"])
+    tb = layout[end+1, :] = LTextbox(scene)
     @test true
 end
 


### PR DESCRIPTION
I honestly forgot what the things were holding this up. I think one thing was that the cursor would be better placed at the right advance of the selected character, now the line is too far left if you type a space for example. Then I'm not sure if the animation loop of the cursor will go on forever if the scene is destroyed while the textbox is active. Other than that, the base functionality seems to work. Oh and what's a bit weird is the internal logic handling an empty text box, I have to cheat and insert a space when that happens because text objects error if they're empty.