### PR TITLE
drop async from LSlider

### DIFF
--- a/src/makielayout/lobjects/lslider.jl
+++ b/src/makielayout/lobjects/lslider.jl
@@ -135,14 +135,12 @@ function LSlider(parent::Scene; bbox = nothing, kwargs...)
             dif[2] / (height(sliderbox[]) - 2pad)
         end
         if fraction != 0.0f0
-            @async begin
-                newfraction = min(max(displayed_sliderfraction[] + fraction, 0f0), 1f0)
-                displayed_sliderfraction[] = newfraction
+            newfraction = min(max(displayed_sliderfraction[] + fraction, 0f0), 1f0)
+            displayed_sliderfraction[] = newfraction
 
-                newindex = closest_fractionindex(sliderrange[], newfraction)
-                if selected_index[] != newindex
-                    selected_index[] = newindex
-                end
+            newindex = closest_fractionindex(sliderrange[], newfraction)
+            if selected_index[] != newindex
+                selected_index[] = newindex
             end
         end
     end


### PR DESCRIPTION
LSlider becomes very slow when triggering more expensive calculations. I tried using it to trigger a ~1.5ms calculation which and it took about 5s to update. This is fixed by removing the `@async`.

With `@async`: (Updates on mouse down are always fast)
![LSlider_with_async](https://user-images.githubusercontent.com/10947937/87544584-ffff1780-c6a6-11ea-92cb-655904168383.gif)

Without `@async`:
![LSlider_no_async](https://user-images.githubusercontent.com/10947937/87544602-0c837000-c6a7-11ea-8a2e-406a19ba8856.gif)
