### PR TITLE
Fix getting `mesh` faces for empty inputs

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -388,7 +388,7 @@ function convert_arguments(
         MT::Type{<:Mesh},
         xyz::AbstractVector
     )
-    faces = connect(UInt32(0):UInt32(length(xyz)-1), GLTriangleFace)
+    faces = connect(UInt32.(0:length(xyz)-1), GLTriangleFace)
     # TODO support faceview natively
     return convert_arguments(MT, xyz, collect(faces))
 end
@@ -416,7 +416,7 @@ function convert_arguments(
         MT::Type{<:Mesh},
         xyz::AbstractVector{<: AbstractPoint}
     )
-    faces = connect(UInt32(0):UInt32(length(xyz)-1), GLTriangleFace)
+    faces = connect(UInt32.(0:length(xyz)-1), GLTriangleFace)
     # TODO support faceview natively
     return convert_arguments(MT, xyz, collect(faces))
 end


### PR DESCRIPTION
Convert indices to `UInt32` after creating range. Partially fixes JuliaPlots/Makie.jl#679.