### PR TITLE
Fix shift and alignment issues

### DIFF
--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -372,7 +372,7 @@ function default_attributes(::Type{LRect}, scene)
         "The extra space added to the sides of the rectangle boundingbox."
         padding = (0f0, 0f0, 0f0, 0f0)
         "The line width of the rectangle's border."
-        strokewidth = 2f0
+        strokewidth = 1f0
         "Controls if the border of the rectangle is visible."
         strokevisible = true
         "The color of the border."

--- a/src/makielayout/helpers.jl
+++ b/src/makielayout/helpers.jl
@@ -174,30 +174,30 @@ function axislines!(scene, rect, spinewidth, topspinevisible, rightspinevisible,
     rightspinecolor, bottomspinecolor)
 
     bottomline = lift(rect, spinewidth) do r, sw
-        y = bottom(r) - 0.5f0 * sw
-        p1 = Point2(left(r) - sw, y)
-        p2 = Point2(right(r) + sw, y)
+        y = bottom(r)
+        p1 = Point2(left(r) - 0.5sw, y)
+        p2 = Point2(right(r) + 0.5sw, y)
         [p1, p2]
     end
 
     leftline = lift(rect, spinewidth) do r, sw
-        x = left(r) - 0.5f0 * sw
-        p1 = Point2(x, bottom(r) - sw)
-        p2 = Point2(x, top(r) + sw)
+        x = left(r)
+        p1 = Point2(x, bottom(r) - 0.5sw)
+        p2 = Point2(x, top(r) + 0.5sw)
         [p1, p2]
     end
 
     topline = lift(rect, spinewidth) do r, sw
-        y = top(r) + 0.5f0 * sw
-        p1 = Point2(left(r) - sw, y)
-        p2 = Point2(right(r) + sw, y)
+        y = top(r)
+        p1 = Point2(left(r) - 0.5sw, y)
+        p2 = Point2(right(r) + 0.5sw, y)
         [p1, p2]
     end
 
     rightline = lift(rect, spinewidth) do r, sw
-        x = right(r) + 0.5f0 * sw
-        p1 = Point2(x, bottom(r) - sw)
-        p2 = Point2(x, top(r) + sw)
+        x = right(r)
+        p1 = Point2(x, bottom(r) - 0.5sw)
+        p2 = Point2(x, top(r) + 0.5sw)
         [p1, p2]
     end
 

--- a/src/makielayout/helpers.jl
+++ b/src/makielayout/helpers.jl
@@ -3,7 +3,12 @@ Shorthand for `isnothing(optional) ? fallback : optional`
 """
 @inline ifnothing(optional, fallback) = isnothing(optional) ? fallback : optional
 
-IRect2D(r::Rect{2}) = Rect{2, Int}(round.(Int, r.origin), round.(Int, r.widths))
+function round_to_IRect2D(r::Rect{2})
+    newori = round.(Int, minimum(r))
+    othercorner = round.(Int, maximum(r))
+    newwidth = othercorner .- newori
+    Rect{2, Int}(newori, newwidth)
+end
 
 function sceneareanode!(finalbbox, limits, aspect)
 
@@ -45,7 +50,7 @@ function sceneareanode!(finalbbox, limits, aspect)
         newbbox = BBox(l, l + mw, b, b + mh)
 
         # only update scene if pixel positions change
-        new_scenearea = IRect2D(newbbox)
+        new_scenearea = round_to_IRect2D(newbbox)
         if new_scenearea != scenearea[]
             scenearea[] = new_scenearea
         end

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -222,14 +222,14 @@ function LineAxis(parent::Scene; kwargs...)
 
         if !trimspine
             if horizontal
-                y = position + (flipped ? 1f0 : -1f0) * 0.5f0 * sw
-                p1 = Point2f0(extents[1] - sw, y)
-                p2 = Point2(extents[2] + sw, y)
+                y = position
+                p1 = Point2f0(extents[1] - 0.5sw, y)
+                p2 = Point2f0(extents[2] + 0.5sw, y)
                 [p1, p2]
             else
-                x = position + (flipped ? 1f0 : -1f0) * 0.5f0 * sw
-                p1 = Point2f0(x, extents[1] - sw)
-                p2 = Point2f0(x, extents[2] + sw)
+                x = position
+                p1 = Point2f0(x, extents[1] - 0.5sw)
+                p2 = Point2f0(x, extents[2] + 0.5sw)
                 [p1, p2]
             end
         else

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -244,9 +244,8 @@ function LineAxis(parent::Scene; kwargs...)
         color = spinecolor, raw = true)[end]
 
 
-    protrusion = lift(ticksvisible, label, labelvisible, labelpadding, labelsize, tickalign, spinewidth,
-            spinevisible, tickspace, ticklabelsvisible, actual_ticklabelspace, ticklabelpad, labelfont, ticklabelfont) do ticksvisible,
-            label, labelvisible, labelpadding, labelsize, tickalign, spinewidth, spinevisible, tickspace, ticklabelsvisible,
+    protrusion = lift(ticksvisible, label, labelvisible, labelpadding, labelsize, tickalign, tickspace, ticklabelsvisible, actual_ticklabelspace, ticklabelpad, labelfont, ticklabelfont) do ticksvisible,
+            label, labelvisible, labelpadding, labelsize, tickalign, tickspace, ticklabelsvisible,
             actual_ticklabelspace, ticklabelpad, labelfont, ticklabelfont
 
         position, extents, horizontal = pos_extents_horizontal[]
@@ -258,11 +257,10 @@ function LineAxis(parent::Scene; kwargs...)
         end
 
         labelspace = (labelvisible && !iswhitespace(label)) ? real_labelsize + labelpadding : 0f0
-        spinespace = spinevisible ? spinewidth : 0f0
         # tickspace = ticksvisible ? max(0f0, xticksize * (1f0 - xtickalign)) : 0f0
         ticklabelgap = ticklabelsvisible ? actual_ticklabelspace + ticklabelpad : 0f0
 
-        together = spinespace + tickspace + ticklabelgap + labelspace
+        together = tickspace + ticklabelgap + labelspace
     end
 
     # trigger whole pipeline once to fill tickpositions and tickstrings

--- a/src/makielayout/lobjects/laxis.jl
+++ b/src/makielayout/lobjects/laxis.jl
@@ -255,10 +255,8 @@ function LAxis(parent::Scene; bbox = nothing, kwargs...)
         left, right, bottom, top = 0f0, 0f0, 0f0, 0f0
 
         if xaxisposition == :bottom
-            topspinevisible && (top = spinewidth)
             bottom = xaxisprotrusion
         else
-            bottomspinevisible && (bottom = spinewidth)
             top = xaxisprotrusion
         end
 
@@ -270,10 +268,8 @@ function LAxis(parent::Scene; bbox = nothing, kwargs...)
         top += titlespace
 
         if yaxisposition == :left
-            rightspinevisible && (right = spinewidth)
             left = yaxisprotrusion
         else
-            leftspinevisible && (left = spinewidth)
             right = yaxisprotrusion
         end
 

--- a/src/makielayout/lobjects/laxis.jl
+++ b/src/makielayout/lobjects/laxis.jl
@@ -169,28 +169,28 @@ function LAxis(parent::Scene; bbox = nothing, kwargs...)
 
     xoppositelinepoints = lift(scene.px_area, spinewidth, xaxisposition) do r, sw, xaxpos
         if xaxpos == :top
-            y = bottom(r) - 0.5f0 * sw
-            p1 = Point2(left(r) - sw, y)
-            p2 = Point2(right(r) + sw, y)
+            y = bottom(r)
+            p1 = Point2(left(r) - 0.5sw, y)
+            p2 = Point2(right(r) + 0.5sw, y)
             [p1, p2]
         else
-            y = top(r) + 0.5f0 * sw
-            p1 = Point2(left(r) - sw, y)
-            p2 = Point2(right(r) + sw, y)
+            y = top(r)
+            p1 = Point2(left(r) - 0.5sw, y)
+            p2 = Point2(right(r) + 0.5sw, y)
             [p1, p2]
         end
     end
 
     yoppositelinepoints = lift(scene.px_area, spinewidth, yaxisposition) do r, sw, yaxpos
         if yaxpos == :right
-            x = left(r) - 0.5f0 * sw
-            p1 = Point2(x, bottom(r) - sw)
-            p2 = Point2(x, top(r) + sw)
+            x = left(r)
+            p1 = Point2(x, bottom(r) - 0.5sw)
+            p2 = Point2(x, top(r) + 0.5sw)
             [p1, p2]
         else
-            x = right(r) + 0.5f0 * sw
-            p1 = Point2(x, bottom(r) - sw)
-            p2 = Point2(x, top(r) + sw)
+            x = right(r)
+            p1 = Point2(x, bottom(r) - 0.5sw)
+            p2 = Point2(x, top(r) + 0.5sw)
             [p1, p2]
         end
     end

--- a/src/makielayout/lobjects/lbutton.jl
+++ b/src/makielayout/lobjects/lbutton.jl
@@ -17,7 +17,7 @@ function LButton(scene::Scene; bbox = nothing, kwargs...)
     textpos = Node(Point2f0(0, 0))
 
     subarea = lift(layoutobservables.computedbbox) do bbox
-        IRect2D(bbox)
+        round_to_IRect2D(bbox)
     end
     subscene = Scene(scene, subarea, camera=campixel!)
 

--- a/src/makielayout/lobjects/lcolorbar.jl
+++ b/src/makielayout/lobjects/lcolorbar.jl
@@ -31,7 +31,7 @@ function LColorbar(parent::Scene; bbox = nothing, kwargs...)
     layoutobservables = LayoutObservables(LColorbar, attrs.width, attrs.height, attrs.tellwidth, attrs.tellheight,
         halign, valign, attrs.alignmode; suggestedbbox = bbox, protrusions = protrusions)
 
-    framebox = layoutobservables.computedbbox
+    framebox = @lift(round_to_IRect2D($(layoutobservables.computedbbox)))
 
     colorlinepoints = lift(framebox, nsteps) do fb, nsteps
         fbw = fb.widths[1]

--- a/src/makielayout/lobjects/llegend.jl
+++ b/src/makielayout/lobjects/llegend.jl
@@ -26,7 +26,7 @@ function LLegend(
     layoutobservables = LayoutObservables(LLegend, attrs.width, attrs.height, attrs.tellwidth, attrs.tellheight,
         halign, valign, attrs.alignmode; suggestedbbox = bbox)
 
-    scenearea = lift(IRect2D, layoutobservables.computedbbox)
+    scenearea = lift(round_to_IRect2D, layoutobservables.computedbbox)
 
     scene = Scene(parent, scenearea, raw = true, camera = campixel!)
 

--- a/src/makielayout/lobjects/lmenu.jl
+++ b/src/makielayout/lobjects/lmenu.jl
@@ -129,7 +129,7 @@ function LMenu(parent::Scene; bbox = nothing, kwargs...)
 
 
     scenearea = lift(layoutobservables.computedbbox, sceneheight, direction) do bbox, h, d
-        IRect2D(BBox(
+        round_to_IRect2D(BBox(
             left(bbox),
             right(bbox),
             d == :down ? top(bbox) - h : bottom(bbox),

--- a/src/makielayout/lobjects/lrect.jl
+++ b/src/makielayout/lobjects/lrect.jl
@@ -14,7 +14,9 @@ function LRect(parent::Scene; bbox = nothing, kwargs...)
         vis ? col : RGBAf0(0, 0, 0, 0)
     end
 
-    r = poly!(parent, layoutobservables.computedbbox, color = color, visible = visible, raw = true,
+    ibbox = @lift(round_to_IRect2D($(layoutobservables.computedbbox)))
+
+    r = poly!(parent, ibbox, color = color, visible = visible, raw = true,
         strokecolor = strokecolor_with_visibility, strokewidth = strokewidth)[end]
 
     # trigger bbox

--- a/src/makielayout/lobjects/lscene.jl
+++ b/src/makielayout/lobjects/lscene.jl
@@ -20,7 +20,7 @@ function LScene(parent::Scene; bbox = nothing, scenekw = NamedTuple(), kwargs...
     layoutobservables = LayoutObservables(LScene, attrs.width, attrs.height, attrs.tellwidth, attrs.tellheight,
         attrs.halign, attrs.valign, attrs.alignmode; suggestedbbox = bbox)
 
-    scene = Scene(parent, lift(IRect2D, layoutobservables.computedbbox); scenekw...)
+    scene = Scene(parent, lift(round_to_IRect2D, layoutobservables.computedbbox); scenekw...)
 
     LScene(scene, attrs, layoutobservables)
 end

--- a/src/makielayout/lobjects/lslider.jl
+++ b/src/makielayout/lobjects/lslider.jl
@@ -27,7 +27,7 @@ function LSlider(parent::Scene; bbox = nothing, kwargs...)
     end
 
     subarea = lift(layoutobservables.computedbbox) do bbox
-        IRect2D(bbox)
+        round_to_IRect2D(bbox)
     end
 
     # the slider gets its own subscene so a click doesn't have to hit the line


### PR DESCRIPTION
the rounded IRect2D was wrong, I should have rounded origin and opposite point, not origin and widths

also I've removed the shift of axis spines by half their width, because that doesn't really help but cause small annoying displacements of ticks and other decorations