### PR TITLE
Removed strokes from arrowheads

### DIFF
--- a/src/basic_recipes/basic_recipes.jl
+++ b/src/basic_recipes/basic_recipes.jl
@@ -234,7 +234,7 @@ function plot!(arrowplot::Arrows{<: Tuple{AbstractVector{<: Point{N, T}}, V}}) w
         arrowplot,
         lift(x-> last.(x), headstart),
         marker = lift(x-> arrow_head(N, x), arrowhead), markersize = arrowsize,
-        color = arrowcolor, rotations = directions
+        color = arrowcolor, rotations = directions,  strokewidth = 0.0,
     )
 end
 


### PR DESCRIPTION
Fixes the issue where arrowheads had strokes, causing rendering errors (a regression introduced by changing the default scatter style)