### PR TITLE
Don't export `transform!` (conflicts with DataFrames.jl)

### DIFF
--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -134,7 +134,7 @@ export to_color, to_colormap, to_rotation, to_font, to_align, to_textsize
 export to_ndim, Reverse
 
 # Transformations
-export translated, translate!, transform!, scale!, rotate!, grid, Accum, Absolute
+export translated, translate!, scale!, rotate!, grid, Accum, Absolute
 export boundingbox, insertplots!, center!, translation, scene_limits
 export hbox, vbox
 


### PR DESCRIPTION
fixes https://github.com/JuliaPlots/Makie.jl/issues/589

this was discussed on Slack a while ago. It is slightly annoying because `transform!` is a central function for working with DataFrames.