### PR TITLE
Add some nospecialize and a few precompiles

### DIFF
--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -227,4 +227,9 @@ end
 
 include("makielayout/MakieLayout.jl")
 
+if Base.VERSION >= v"1.4.2"
+    include("precompile.jl")
+    _precompile_()
+end
+
 end # module

--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -264,6 +264,7 @@ function calculated_attributes!(::Type{<: Union{Axis2D, Axis3D}}, plot)
     ticks = plot.ticks
     args = (plot.padding, plot[1], ticks.ranges, ticks.labels, ticks.formatter)
     ticks[:ranges_labels] = lift(args...) do pad, lims, ranges, labels, formatter
+        # TODO precompile?
         limit_widths = map(x-> x[2] - x[1], lims)
         pad = (limit_widths .* pad)
         # pad the drawn limits and use them as the ranges
@@ -382,6 +383,7 @@ function draw_titles(
         textcolor, textsize, rotation, align, font,
         title
     )
+    @nospecialize
 
     tickspace_x = maximum(map(yticks) do tick
         str = last(tick)
@@ -462,6 +464,7 @@ function draw_axis2d(
         ti_labels,
         ti_textcolor, ti_textsize, ti_rotation, ti_align, ti_font, ti_title
     )
+    @nospecialize
     xyrange, labels = xyrange_labels
     start!(textbuffer); start!(frame_linebuffer); foreach(start!, grid_linebuffer)
     foreach(start!, tickmarks_linebuffer)
@@ -602,6 +605,7 @@ to3tuple(x::Tuple{Any, Any, Any}) = x
 to3tuple(x) = ntuple(i-> x, Val(3))
 
 function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
+    @nospecialize
     # make sure we extend all args to 3D
     ranges, labels = ranges_labels
     args3d = to3tuple.(args)

--- a/src/basic_recipes/errorbars.jl
+++ b/src/basic_recipes/errorbars.jl
@@ -54,7 +54,7 @@ function _plot_errorbars!(plot, xys, low, high)
     whiskers = lift(linesegpairs, scene.camera.projectionview,
         scene.camera.pixel_space, whiskerwidth) do pairs, _, _, whiskerwidth
 
-        endpoints = [p for pair in pairs for p in pair]
+        endpoints = [p for pair in pairs for p in pair]  # TODO precompile?
 
         screenendpoints = scene_to_screen(endpoints, scene)
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -38,6 +38,7 @@ struct SurfaceLike <: ConversionTrait end
 conversion_trait(::Type{<: Union{Surface, Heatmap, Image}}) = SurfaceLike()
 
 function convert_arguments(T::PlotFunc, args...; kw...)
+    @nospecialize
     ct = conversion_trait(T)
     try
         convert_arguments(ct, args...; kw...)
@@ -568,6 +569,7 @@ function convert_arguments(P::PlotFunc, r::AbstractVector, f::Function)
 end
 
 function convert_arguments(P::PlotFunc, i::AbstractInterval, f::Function)
+    @nospecialize
     x, y = PlotUtils.adapted_grid(f, endpoints(i))
     ptype = plottype(P, Lines)
     to_plotspec(ptype, convert_arguments(ptype, x, y))

--- a/src/dictlike.jl
+++ b/src/dictlike.jl
@@ -42,11 +42,11 @@ node_pairs(pair::Union{Pair, Tuple{Any, Any}}) = (pair[1] => convert(Node{Any}, 
 node_pairs(pairs) = (node_pairs(pair) for pair in pairs)
 
 
-Attributes(; kw_args...) = Attributes(Dict{Symbol, Node}(node_pairs(kw_args)))
-Attributes(pairs::Pair...) = Attributes(Dict{Symbol, Node}(node_pairs(pairs)))
-Attributes(pairs::AbstractVector) = Attributes(Dict{Symbol, Node}(node_pairs.(pairs)))
-Attributes(pairs::Iterators.Pairs) = Attributes(collect(pairs))
-Attributes(nt::NamedTuple) = Attributes(; nt...)
+Attributes(; kw_args...) = (@nospecialize; Attributes(Dict{Symbol, Node}(node_pairs(kw_args))))
+Attributes(pairs::Pair...) = (@nospecialize; Attributes(Dict{Symbol, Node}(node_pairs(pairs))))
+Attributes(@nospecialize(pairs::AbstractVector)) = Attributes(Dict{Symbol, Node}(node_pairs.(pairs)))
+Attributes(@nospecialize(pairs::Iterators.Pairs)) = Attributes(collect(pairs))
+Attributes(@nospecialize(nt::NamedTuple)) = Attributes(; nt...)
 attributes(x::Attributes) = getfield(x, :attributes)
 Base.keys(x::Attributes) = keys(x.attributes)
 Base.values(x::Attributes) = values(x.attributes)
@@ -129,7 +129,7 @@ _indent_attrs(s, n) = join(split(s, '\n'), "\n" * " "^n)
 function Base.show(io::IO,::MIME"text/plain", attr::Attributes)
 
     io = IOContext(io, :compact => true)
-    
+
     d = Dict()
     print(io, """Attributes with $(length(attr)) $(length(attr) != 1 ? "entries" : "entry")""")
 

--- a/src/interaction/nodes.jl
+++ b/src/interaction/nodes.jl
@@ -5,6 +5,7 @@ function lift(
         init = f(to_value(o1), to_value.(rest)...), typ = typeof(init),
         name = :node # name ignored for now
     )
+    @nospecialize
     result = Observable{typ}(init)
     map!(f, result, o1, rest...)
 end

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -385,6 +385,7 @@ apply for return type
     (args...,)
 """
 function apply_convert!(P, attributes::Attributes, x::Tuple)
+    @nospecialize
     return (plottype(P, x...), x)
 end
 
@@ -402,6 +403,7 @@ function apply_convert!(P, attributes::Attributes, x::PlotSpec{S}) where S
 end
 
 function seperate_tuple(args::Node{<: NTuple{N, Any}}) where N
+    @nospecialize
     ntuple(N) do i
         lift(args) do x
             if i <= length(x)
@@ -435,6 +437,7 @@ function plot(scene::Scene, plot::AbstractPlot)
 end
 
 function (PlotType::Type{<: AbstractPlot{Typ}})(scene::SceneLike, attributes::Attributes, input, args) where Typ
+    @nospecialize
     # The argument type of the final plot object is the assumened to stay constant after
     # argument conversion. This might not always hold, but it simplifies
     # things quite a bit
@@ -543,6 +546,7 @@ const PlotFunc = Union{Type{Any}, Type{<: AbstractPlot}}
 # non-mutating, without positional attributes
 
 function plot(P::PlotFunc, args...; kw_attributes...)
+    @nospecialize
     attributes = Attributes(kw_attributes)
     plot(P, attributes, args...)
 end
@@ -550,6 +554,7 @@ end
 # with positional attributes
 
 function plot(P::PlotFunc, attrs::Attributes, args...; kw_attributes...)
+    @nospecialize
     attributes = merge!(Attributes(kw_attributes), attrs)
     scene_attributes = extract_scene_attributes!(attributes)
     scene = Scene(; scene_attributes...)
@@ -559,6 +564,7 @@ end
 # mutating, without positional attributes
 
 function plot!(P::PlotFunc, scene::SceneLike, args...; kw_attributes...)
+    @nospecialize
     attributes = Attributes(kw_attributes)
     plot!(scene, P, attributes, args...)
 end
@@ -566,12 +572,14 @@ end
 # without scenelike, use current scene
 
 function plot!(P::PlotFunc, args...; kw_attributes...)
+    @nospecialize
     plot!(P, current_scene(), args...; kw_attributes...)
 end
 
 # with positional attributes
 
 function plot!(P::PlotFunc, scene::SceneLike, attrs::Attributes, args...; kw_attributes...)
+    @nospecialize
     attributes = merge!(Attributes(kw_attributes), attrs)
     plot!(scene, P, attributes, args...)
 end
@@ -592,6 +600,7 @@ plotfunc(::Combined{F}) where F = F
 Main plotting signatures that plot/plot! route to if no Plot Type is given
 """
 function plot!(scene::SceneLike, P::PlotFunc, attributes::Attributes, args...; kw_attributes...)
+    @nospecialize
     attributes = merge!(Attributes(kw_attributes), attributes)
     argvalues = to_value.(args)
     PreType = plottype(P, argvalues...)
@@ -678,7 +687,8 @@ function extract_scene_attributes!(attributes)
     return result
 end
 
-function plot!(scene::SceneLike, P::PlotFunc, attributes::Attributes, input::NTuple{N, Node}, args::Node) where {N}
+function plot!(scene::SceneLike, P::PlotFunc, attributes::Attributes, input::Tuple{Vararg{Node}}, args::Node)
+    @nospecialize
     # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
     scene_attributes = extract_scene_attributes!(attributes)
     plot_object = P(scene, copy(attributes), input, args)

--- a/src/layouting/boundingbox.jl
+++ b/src/layouting/boundingbox.jl
@@ -154,6 +154,7 @@ function boundingbox(
         # the boundingbox slightly changes size in each frame (in MakieLayout mostly)
         use_vertical_dimensions_from_font = true
     )
+    @nospecialize
     atlas = get_texture_atlas()
     N = length(text)
     ctext_state = iterate(text)

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -5,7 +5,7 @@ function data_limits(x)
     error("No datalimits for $(typeof(x)) and $(argtypes(x))")
 end
 
-function data_limits(x::Atomic)
+function data_limits(@nospecialize(x::Atomic))
     isempty(x.plots) ? atomic_limits(x) : data_limits(x.plots)
 end
 

--- a/src/makielayout/MakieLayout.jl
+++ b/src/makielayout/MakieLayout.jl
@@ -108,4 +108,9 @@ export swap!
 export ncols, nrows
 export contents
 
+if Base.VERSION >= v"1.4.2"
+    include("precompile.jl")
+    _precompile_()
+end
+
 end # module

--- a/src/makielayout/lobjects/llegend.jl
+++ b/src/makielayout/lobjects/llegend.jl
@@ -171,6 +171,7 @@ function LLegend(
     end
 
     on(entry_groups) do entry_groups
+        # TODO: precompile?
         # first delete all existing labels and patches
 
         for t in titletexts
@@ -412,7 +413,7 @@ one content element. A content element can be an `AbstractPlot`, an array of
 `legendelements` method is defined.
 """
 function LLegend(scene,
-        contents::AbstractArray,
+        @nospecialize(contents::AbstractArray),
         labels::AbstractArray{String},
         title::Optional{String} = nothing;
         kwargs...)

--- a/src/makielayout/precompile.jl
+++ b/src/makielayout/precompile.jl
@@ -1,0 +1,13 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    @assert precompile(LLegend, (Scene, Node{Vector{Tuple{Optional{String}, Vector{LegendEntry}}}}))
+    @assert precompile(LLegend, (Scene, AbstractArray, Vector{String}))
+    @assert precompile(LColorbar, (Scene,))
+    @assert precompile(LAxis, (Scene,))
+    @assert precompile(LMenu, (Scene,))
+    @assert precompile(LButton, (Scene,))
+    @assert precompile(LSlider, (Scene,))
+    @assert precompile(LTextbox, (Scene,))
+
+    @assert precompile(layoutscene, ())
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,20 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    # for T in (Float32, Float64, Int)
+    #     @assert precompile(plot, (Vector{T},))
+    # end
+    # @assert precompile(plot!, (Annotations,))
+    # @assert precompile(plot!, (SceneLike, PlotFunc, Attributes, Tuple{Vararg{Node}}, Node))
+    @assert precompile(peaks, ())
+    @assert precompile(logo, ())
+    @assert precompile(poly_convert, (Vector{Vector{Point{2,Float32}}},))
+    @assert precompile(poly_convert, (Vector{GeometryBasics.HyperRectangle{2,Float32}},))
+    @assert precompile(poly_convert, (Vector{GeometryBasics.HyperRectangle{2,Int}},))
+    @assert precompile(poly_convert, (Vector{HyperSphere{2,Float32}},))
+    @assert precompile(rotatedrect, (GeometryBasics.HyperRectangle{2,Float32}, Float32))
+    @assert precompile(display, (PlotDisplay, Scene))
+    @assert precompile(push!, (Scene, AbstractPlot))
+
+    @assert precompile(Core.kwfunc(axis2d!), (NamedTuple{(:ticks,), Tuple{NamedTuple{(:ranges, :labels), Tuple{Automatic, Automatic}}}}, typeof(axis2d!), Scene, Vararg{Any}))
+    @assert precompile(Core.kwfunc(poly!), (NamedTuple{(:color, :strokewidth, :raw),Tuple{Observable{Any},Int64,Bool}}, typeof(poly!), Scene, Vararg{Any}))
+end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -9,10 +9,12 @@ The `Core.@__doc__` macro transfers the docstring given to the Recipe into the f
 function default_plot_signatures(funcname, funcname!, PlotType)
     quote
         Core.@__doc__ function ($funcname)(args...; attributes...)
+            @nospecialize
             plot($PlotType, args...; attributes...)
         end
 
         Core.@__doc__ function ($funcname!)(args...; attributes...)
+            @nospecialize
             plot!($PlotType, args...; attributes...)
         end
     end
@@ -126,6 +128,7 @@ macro recipe(theme_func, Tsym::Symbol, args::Symbol...)
     funcname! = esc(Symbol("$(funcname_sym)!"))
     PlotType = esc(Tsym)
     funcname = esc(funcname_sym)
+    # TODO: use @nospecialize in the ::Type arguments (but have to distenangle from the esc)
     expr = quote
         $(funcname)() = not_implemented_for($funcname)
         const $(PlotType){$(esc(:ArgType))} = Combined{$funcname, $(esc(:ArgType))}

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -338,7 +338,7 @@ theme(x::AbstractPlot, key) = x.attributes[key]
 theme(::Nothing, key::Symbol) = current_default_theme()[key]
 
 Base.push!(scene::Combined, subscene) = nothing # Combined plots add themselves uppon creation
-function Base.push!(scene::Scene, plot::AbstractPlot)
+function Base.push!(scene::Scene, @nospecialize(plot::AbstractPlot))
     push!(scene.plots, plot)
     plot isa Combined || (plot.parent[] = scene)
     if !scene.raw[]

--- a/src/stats/crossbar.jl
+++ b/src/stats/crossbar.jl
@@ -1,4 +1,4 @@
-#= 
+#=
 S. Axen implementation from https://github.com/JuliaPlots/StatsMakie.jl/blob/master/src/recipes/crossbar.jl#L22
 The StatMakie.jl package is licensed under the MIT "Expat" License:
     Copyright (c) 2018: Pietro Vertechi. =#
@@ -53,6 +53,7 @@ function AbstractPlotting.plot!(plot::CrossBar)
         plot[4],
         args...,
     ) do x, y, ymin, ymax, bw, show_notch, nmin, nmax, nw, orientation
+        # TODO precompile this?
         show_notch = show_notch && (nmin !== automatic && nmax !== automatic)
 
         # for horizontal crossbars just flip all components

--- a/src/stats/violin.jl
+++ b/src/stats/violin.jl
@@ -17,11 +17,12 @@ function plot!(plot::Violin)
     width, side, trim, show_median = plot[:width], plot[:side], plot[:trim], plot[:show_median]
 
     signals = lift(plot[1], plot[2], width, side, trim, show_median) do x, y, bw, vside, trim, show_median
+        # TODO: would be lovely to precompile this
         vertices = Vector{Point2f0}[]
         lines = Pair{Point2f0, Point2f0}[]
         for (key, idxs) in StructArrays.finduniquesorted(x)
             v = view(y, idxs)
-            
+
             spec = (x = key, kde = density(v; trim = trim), median = median(v))
             min, max = extrema_nan(spec.kde.density)
             scale = 0.5*bw/max


### PR DESCRIPTION
This, together with some companion PRs in several other packages, shaves about 30s off the time to run the tests in this package (from 214s to 187s). Its effect on TTFP is fairly minimal (maybe shaves off 2.5s, which appears to be bigger than the noise but not massively so).

A few comments are in order. The main trick here is to add `@nospecialize`. There is some risk that this could lead to a runtime penalty, but I don't know these packages well enough to say. Consequently, this is something that is better analyzed by people more knowledgeable than I. Of course lack of specialization will only affect methods that do "real work," and from what I could tell most/all of these just call the things that do the real work. But I could easily be mistaken.

Second, I added a few precompiles. I typically add an `@assert` in front of these so that I know whether they have gone stale (if `precompile` can't find the method from the supplied signature, it just returns `false` rather than errorring). Feel free to strip the `@assert`s if you prefer to not be bothered due to API refactoring. However, this revealed something quite interesting: some of your signatures simply can't be precompiled. I left a note in one of these packages about the ultimate origin. I did not poke at this quite long enough to figure out why it doesn't work.

Third, there are quite a lot of anonymous functions that would be nice to precompile. I've marked many of them, but to make that work robustly you'd actually have to split them out and name them. Alternatively, perhaps one could insert `@nospecialize`s in those `do` blocks too? (I've never tried.)

Finally, I only tested on Julia 1.6; on 1.5, you might get so much invalidation that these precompiles won't help. But the `@nospecialize` should be useful regardless.

At the end, `display(plot(rand(5)))` was still about half inference time. That suggests there is probably significantly more progress to be made. Consequently, let me summarize my workflow. I use `SnoopCompileCore`'s `@snoopi`, but these days I almost never run the "automated" precompile generation stuff. Instead, I look at the results, think about them, and then intervene manually. I only worry about the big ones, say with an inference time bigger than 100ms, since for now you still have some really expensive-to-infer calls.

To detect excessive specialization, here are some good tricks. Let's say you've collected the `@snoopi` results to a variable `tinf::Vector{Tuple{Float64,MethodInstance}}`. That list (which is sorted in order of inference time) shows you the "bad actors" for *specific* types, but sometimes if you're inferring dozens of specializations then even a cheaper-to-infer method can add up. Consequently a nice trick (which I discovered while looking at this package) is
```julia
mtimes = Dict{Method,Float64}()
for (t, mi) in tinf
    meth = mi.def
    if isa(meth, Method)
        mtimes[meth] = t + get(mtimes, meth, 0.0)
    end
end
tinfm = [(v, k) for (k, v) in mtimes];
sort!(tinfm; by=first)
```
which aggregates all the MethodInstances associated with a single Method. If you see some methods that are "bad actors," then you can use `filter` to pull all the corresponding `MethodInstance`s out of `tinf`; if there are a lot of them, consider adding a `@nospecialize`.

Finally, in the long run you should consider whether you need to specify as much via type parameters as you do. Some of the structs have abstract fields, and in such cases you're not going to be able to infer your dispatches anyway, so the specialization is only costing you. An example of a package where I've successfully defeated the overhead of excessive specialization is FileIO; it used to be horrible for latency, but I've finally essentially disabled all the relevant specialization (see a sequence of PRs of mine over the last several months) and it's much lighter weight now. But a good alternative is to not use so many type parameters for things. For example, in FileIO with 20/20 hindsight we could have defined a file format to have a `::Module` or `::Vector{Module}` field, and then used something like
```julia
load = getfield(format.module, :load)
load(filename, args; kwargs...)
```
and had only one format type (instead of one type per file format).