### PR TITLE
Don't specialize `show` for types

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -129,7 +129,6 @@ macro recipe(theme_func, Tsym::Symbol, args::Symbol...)
     expr = quote
         $(funcname)() = not_implemented_for($funcname)
         const $(PlotType){$(esc(:ArgType))} = Combined{$funcname, $(esc(:ArgType))}
-        Base.show(io::IO, ::Type{<: $PlotType}) = print(io, $(string(Tsym)), "{...}")
         $(default_plot_signatures(funcname, funcname!, PlotType))
         AbstractPlotting.default_theme(scene, ::Type{<: $PlotType}) = $(esc(theme_func))(scene)
         export $PlotType, $funcname, $funcname!


### PR DESCRIPTION
I suspect you still shouldn't be doing this...and it makes it much harder to find good `precompile` directives if you can't see the actual types being created.