### PR TITLE
better error message for setting limits of empty scene

### DIFF
--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -52,11 +52,29 @@ zlabel!(zlabel::AbstractString) = zlabel!(current_scene(), zlabel)
 ################################################################################
 """
     setlims!(scene::Scene, min_max::NTuple{2, Real}, dim=1)
-    
+
 Sets the limits of the scene for dim=1.
 """
 function setlims!(scene::Scene, min_max::NTuple{2, Real}, dim=1)
     ol = scene_limits(scene)             # get the Scene's limits as values
+    if ol === nothing
+        msg = """
+        Setting limits of empty scene is currently not supported.
+        A possible workaround is to replace code like:
+        ```julia
+        scene = Scene(...)
+        ylims!(scene, ...)
+        plot!(scene, ...)
+        ```
+        by code like:
+        ```julia
+        scene = Scene(...)
+        plot!(scene, ...)
+        ylims!(scene, ...)
+        ```
+        """
+        throw(ArgumentError(msg))
+    end
     o_origin = minimum(ol)                         # get the original origin
     o_widths = widths(ol)                         # get the original widths
     n_widths = convert(Vector, o_widths)         # convert to mutable form

--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -72,6 +72,11 @@ function setlims!(scene::Scene, min_max::NTuple{2, Real}, dim=1)
         plot!(scene, ...)
         ylims!(scene, ...)
         ```
+        or code like:
+        ```julia
+        scene = Scene(limits=FRect2D(0,0,5, 5))
+        plot!(scene, ...)
+        ```
         """
         throw(ArgumentError(msg))
     end

--- a/test/shorthands.jl
+++ b/test/shorthands.jl
@@ -1,5 +1,17 @@
 @testset "shorthands" begin
 
+    @testset "xlims!" begin
+        # test xlims of empty scene throws sane error
+        scene = Scene()
+        @test_throws ArgumentError xlims!(scene, (0,1))
+        @test_throws ArgumentError ylims!(scene, (0,1))
+        @test_throws ArgumentError zlims!(scene, (0,1))
+        lines!(scene, rand(3), rand(3), rand(3))
+        xlims!(scene, (0,1))
+        ylims!(scene, (0,1))
+        zlims!(scene, (0,1))
+    end
+
     scene2d = scatter(1:10, 1:10);
     scene = scatter(1:10, 1:10, 1:10);
     axis = scene[Axis]


### PR DESCRIPTION
# Error before:

```
MethodError: no method matching iterate(::Nothing)
Closest candidates are:
  iterate(!Matched::Base.EnvDict) at env.jl:119
  iterate(!Matched::Base.EnvDict, !Matched::Any) at env.jl:119
  iterate(!Matched::DataStructures.SparseIntSet, !Matched::Any...) at /home/jan/.julia/packages/DataStructures/CINja/src/sparse_int_set.jl:147
  ...

Stacktrace:
 [1] _foldl_impl(::Base.BottomRF{typeof(min)}, ::Base._InitialValue, ::Nothing) at ./reduce.jl:56
 [2] foldl_impl(::Base.BottomRF{typeof(min)}, ::NamedTuple{(),Tuple{}}, ::Nothing) at ./reduce.jl:48
 [3] mapfoldl_impl(::typeof(identity), ::typeof(min), ::NamedTuple{(),Tuple{}}, ::Nothing) at ./reduce.jl:44
 [4] mapfoldl(::Function, ::Function, ::Nothing; kw::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./reduce.jl:160
 [5] mapfoldl(::Function, ::Function, ::Nothing) at ./reduce.jl:160
 [6] mapreduce(::Function, ::Function, ::Nothing; kw::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./reduce.jl:287
 [7] mapreduce(::Function, ::Function, ::Nothing) at ./reduce.jl:287
 [8] minimum(::Nothing) at ./reduce.jl:668
 [9] setlims!(::Scene, ::Tuple{Int64,Int64}, ::Int64) at /home/jan/.julia/packages/AbstractPlotting/rWfRe/src/shorthands.jl:60
 [10] xlims!(::Scene, ::Tuple{Int64,Int64}) at /home/jan/.julia/packages/AbstractPlotting/rWfRe/src/shorthands.jl:79
 [11] top-level scope at In[18]:5
 [12] include_string(::Function, ::Module, ::String, ::String) at ./loading.jl:1091
```

# Error after:

```
ERROR: ArgumentError: Setting limits of empty scene is currently not supported.
A possible workaround is to replace code like:
\```julia
scene = Scene(...)
ylims!(scene, ...)
plot!(scene, ...)
\```
by code like:
\```julia
scene = Scene(...)
plot!(scene, ...)
ylims!(scene, ...)
\```

Stacktrace:
 [1] setlims!(::Scene, ::Tuple{Int64,Int64}, ::Int64) at /home/jan/.julia/dev/AbstractPlotting/src/shorthands.jl:76
 [2] xlims!(::Scene, ::Tuple{Int64,Int64}) at /home/jan/.julia/dev/AbstractPlotting/src/shorthands.jl:97
 [3] top-level scope at REPL[1]:1
```