### PR TITLE
Axis3D fixes/adjustments

### DIFF
--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -133,7 +133,7 @@ $(ATTRIBUTES)
             textsize = (6.0, 6.0, 6.0),
             align = axisnames_align3d,
             font = lift(dim3, theme(scene, :font)),
-            gap = 1
+            gap = 3
         ),
 
         ticks = Attributes(
@@ -145,7 +145,7 @@ $(ATTRIBUTES)
             rotation = tickrotations3d,
             textsize = (tsize, tsize, tsize),
             align = tickalign3d,
-            gap = 1,
+            gap = 3,
             font = lift(dim3, theme(scene, :font)),
         ),
 
@@ -618,10 +618,10 @@ function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
     ranges_ticks = Pair.(ranges, labels)
     mini, maxi = first.(limits), last.(limits)
 
-    ranges = map(i-> [mini[i]; first(ranges_ticks[i]); maxi[i]], 1:3)
-    ticklabels = map(x-> [""; last(x); ""], ranges_ticks)
-    origin = Point{N, Float32}(mini)
-    limit_widths = maxi .- mini
+    ranges = map(i-> [mini[i]; first(ranges_ticks[i])], 1:3)
+    ticklabels = map(x-> [""; last(x)], ranges_ticks)
+    origin = Point{N, Float32}(min.(mini, getindex.(ranges, 2)))
+    limit_widths = max.(last.(ranges), maxi) .- origin
     % = minimum(limit_widths) / 100 # percentage
     ttextsize = (%) .* ttextsize
     axisnames_size = (%) .* axisnames_size
@@ -630,7 +630,7 @@ function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
     tgap = (%) .* tgap
     for i = 1:N
         axis_vec = unit(Point{N, Float32}, i)
-        width = _widths(ranges[i])
+        width = Float32(limit_widths[i])
         stop = origin .+ (width .* axis_vec)
         if showaxis[i]
             append!(linebuffer, [origin, stop], color = axiscolors[i], linewidth = 1.5f0)
@@ -641,17 +641,17 @@ function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
             tickdir = unit(Point{N, Float32}, j)
             tickdir, offset2 = if i != 2
                 tickdir = unit(Vec{N, Float32}, j)
-                tickdir, Float32(_widths(ranges[j]) + tgap[i]) * tickdir
+                tickdir, Float32(limit_widths[j] + tgap[i]) * tickdir
             else
                 tickdir = unit(Vec{N, Float32}, 1)
-                tickdir, Float32(_widths(ranges[1]) + tgap[i]) * tickdir
+                tickdir, Float32(limit_widths[1] + tgap[i]) * tickdir
             end
             for (j, tick) in enumerate(range)
                 labels = ticklabels[i]
                 if length(labels) >= j
                     str = labels[j]
                     if !isempty(str)
-                        startpos = (origin .+ ((Float32(tick - range[1]) * axis_vec)) .+ offset2)
+                        startpos = (origin .+ ((Float32(tick - origin[i]) * axis_vec)) .+ offset2)
                         push!(
                             textbuffer, str, startpos,
                             color = ttextcolor[i], rotation = trotation[i],
@@ -682,7 +682,7 @@ function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
                 dir = unit(Point{N, Float32}, j)
                 range = ranges[j]
                 for tick in drop(range, 1)
-                    offset = Float32(tick - range[1]) * dir
+                    offset = Float32(tick - origin[j]) * dir
                     append!(
                         linebuffer, [origin .+ offset, stop .+ offset],
                         color = c, linewidth = thickness

--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -603,7 +603,7 @@ to3tuple(x) = ntuple(i-> x, Val(3))
 
 function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
     # make sure we extend all args to 3D
-    ranges, labels = ranges_labels
+    ranges, ticklabels = ranges_labels
     args3d = to3tuple.(args)
     (
         showaxis, showticks, showgrid,
@@ -615,12 +615,9 @@ function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
 
     N = 3
     start!(textbuffer); start!(linebuffer)
-    ranges_ticks = Pair.(ranges, labels)
     mini, maxi = first.(limits), last.(limits)
 
-    ranges = map(i-> [mini[i]; first(ranges_ticks[i])], 1:3)
-    ticklabels = map(x-> [""; last(x)], ranges_ticks)
-    origin = Point{N, Float32}(min.(mini, getindex.(ranges, 2)))
+    origin = Point{N, Float32}(min.(mini, first.(ranges)))
     limit_widths = max.(last.(ranges), maxi) .- origin
     % = minimum(limit_widths) / 100 # percentage
     ttextsize = (%) .* ttextsize
@@ -681,7 +678,7 @@ function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
                 j = mod1(_j, N)
                 dir = unit(Point{N, Float32}, j)
                 range = ranges[j]
-                for tick in drop(range, 1)
+                for tick in range
                     offset = Float32(tick - origin[j]) * dir
                     append!(
                         linebuffer, [origin .+ offset, stop .+ offset],

--- a/test/shorthands.jl
+++ b/test/shorthands.jl
@@ -12,20 +12,23 @@
         zlims!(scene, (0,1))
     end
 
+    # update! is called when a scene is displayed and may cause ticks to change
     scene2d = scatter(1:10, 1:10);
+    update!(scene2d)
     scene = scatter(1:10, 1:10, 1:10);
+    update!(scene)
     axis = scene[Axis]
 
     @testset "tick labels" begin
 
-        @test xticklabels(scene) == ["2", "4", "6", "8", "10"]
-        @test yticklabels(scene) ==  ["0.0", "2.5", "5.0", "7.5", "10.0"]
-        @test zticklabels(scene) == ["2", "4", "6", "8", "10"]
+        @test xticklabels(scene) == ["0.0", "2.5", "5.0", "7.5", "10.0"]
+        @test yticklabels(scene) == ["0.0", "2.5", "5.0", "7.5", "10.0"]
+        @test zticklabels(scene) == ["0.0", "2.5", "5.0", "7.5", "10.0"]
         @test_throws AssertionError("The Scene does not have a z-axis!") zticklabels(scene2d)
 
-        @test xtickrange(scene) == [2.0, 4.0, 6.0, 8.0, 10.0]
+        @test xtickrange(scene) == [0.0, 2.5, 5.0, 7.5, 10.0]
         @test ytickrange(scene) == [0.0, 2.5, 5.0, 7.5, 10.0]
-        @test ztickrange(scene) == [2.0, 4.0, 6.0, 8.0, 10.0]
+        @test ztickrange(scene) == [0.0, 2.5, 5.0, 7.5, 10.0]
         @test_throws AssertionError("The Scene does not have a z-axis!") ztickrange(scene2d)
 
         xticks!(scene, xticklabels=["a", "b", "c", "d", "e"])


### PR DESCRIPTION
Sometimes axis grid lines end up outside the region suggested by the main axis lines. I fixed that by setting the origin to the minimum of the tick positions and data limits. I also adjusted the default spacing of tick labels and axis names to bit a larger and removed the outer most grid line. 

Before:
![Screenshot from 2020-09-26 17-49-13](https://user-images.githubusercontent.com/10947937/94344962-2c2e0180-0023-11eb-970d-a0c1131e7b75.png)

After:
![Screenshot from 2020-09-26 17-44-19](https://user-images.githubusercontent.com/10947937/94344966-32bc7900-0023-11eb-9ee4-6398aeabad05.png)



