### PR TITLE
project(::Scene,::T<:StaticVector) to mirror the to_world method

### DIFF
--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -307,6 +307,16 @@ function to_world(
         to_world(zeros(Point{N, T}), prj_view_inv, cam_res)
 end
 
+function project(scene::Scene,point::T) where T<:StaticVector
+    cam = scene.camera
+    project(
+        cam.projection[] * 
+        cam.view[] * 
+        transformationmatrix(scene)[],
+        Vec2(scene.resolution[]), point
+    )
+end
+
 function project(matrix::Mat4f0, p::T, dim4 = 1.0) where T <: VecTypes
     p = to_ndim(Vec4f0, to_ndim(Vec3f0, p, 0.0), dim4)
     p = matrix * p


### PR DESCRIPTION
This adds a `project` method taking a `Scene` as input, the same way there is a `to_world` method which takes a `Scene` as input. Using a `Scene` as input instead of some projection matrix should make things easier for the end user.