### PR TITLE
Add some precompiles relevant for layouts

### DIFF
--- a/src/makielayout/MakieLayout.jl
+++ b/src/makielayout/MakieLayout.jl
@@ -108,4 +108,9 @@ export swap!
 export ncols, nrows
 export contents
 
+if Base.VERSION >= v"1.4.2"
+    include("precompile.jl")
+    _precompile_()
+end
+
 end # module

--- a/src/makielayout/precompile.jl
+++ b/src/makielayout/precompile.jl
@@ -1,0 +1,16 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    @assert precompile(LLegend, (Scene, Node{Vector{Tuple{Optional{String}, Vector{LegendEntry}}}}))
+    # @assert precompile(LLegend, (Scene, AbstractArray, Vector{String}))
+    @assert precompile(LColorbar, (Scene,))
+    @assert precompile(LAxis, (Scene,))
+    # @assert precompile(Core.kwfunc(Type), (NamedTuple{(:title,), Tuple{String}}, Type{LAxis}, Scene))
+    @assert precompile(LineAxis, (Scene,))
+    @assert precompile(LMenu, (Scene,))
+    @assert precompile(LButton, (Scene,))
+    @assert precompile(LSlider, (Scene,))
+    @assert precompile(LTextbox, (Scene,))
+
+    @assert precompile(layoutscene, ())  # doesn't fully precompile
+    @assert precompile(get_ticklabels, (AbstractPlotting.Automatic, AbstractPlotting.Automatic, Vector{Float64}))
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -4,4 +4,17 @@ function _precompile_()
     @assert precompile(update_limits!, (Scene,))
     @assert precompile(update_limits!, (Scene, Automatic))
     @assert precompile(update_limits!, (Scene, FRect3D))
+
+    @assert precompile(boundingbox, (Scene,))
+    Ngonf0 = GeometryBasics.Ngon{2, Float32, 3, Point2f0}
+    # @assert precompile(boundingbox, (Mesh{Tuple{Vector{GeometryBasics.Mesh{2, Float32, Ngonf0, FaceView{Ngonf0}}}}},))  # doesn't seem to work
+    @assert precompile(boundingbox, (Poly{Tuple{Vector{Vector{Point2f0}}}},))
+    @assert precompile(boundingbox, (String, Vector{Point3f0}, Vector{Float32}, Vector{FTFont}, Vec2f0, Vector{Quaternionf0}, SMatrix{4, 4, Float32, 16}, Float64, Float64))
+
+    @assert precompile(poly_convert, (Vector{Vector{Point2f0}},))
+    @assert precompile(rotatedrect, (FRect2D, Float32))
+
+    @assert precompile(plot!, (Scene, Type{Poly{Tuple{IRect2D}}}, Attributes, Tuple{Observable{IRect2D}}, Observable{Tuple{Vector{Vector{Point2f0}}}}))
+    @assert precompile(plot!, (Mesh{Tuple{Vector{GeometryBasics.Mesh{2, Float32, Ngonf0, FaceView{Ngonf0}}}}},))
+    @assert precompile(plot!, (Scene, Type{Annotations{Tuple{Vector{Tuple{String, Point2f0}}}}}, Attributes, Tuple{Observable{Vector{Tuple{String, Point2f0}}}}, Observable{Tuple{Vector{Tuple{String, Point2f0}}}}))
 end


### PR DESCRIPTION
This shaves about 3s off `LAxis(scene, title = " ")`