### PR TITLE
Fix and test pan/zoom

### DIFF
--- a/src/interaction/interactive_api.jl
+++ b/src/interaction/interactive_api.jl
@@ -146,15 +146,15 @@ rectangle has area > 0.
 
 The `kwargs...` are propagated into `lines!` which plots the selected rectangle.
 """
-function select_rectangle(scene; kwargs...)
+function select_rectangle(scene; strokewidth = 3.0, kwargs...)
     key = Mouse.left
     waspressed = Node(false)
     rect = Node(FRect(0, 0, 1, 1)) # plotted rectangle
     rect_ret = Node(FRect(0, 0, 1, 1)) # returned rectangle
 
     # Create an initially hidden rectangle
-    plotted_rect = lines!(
-        scene, rect, raw = true, visible = false, color = RGBAf0(0.1, 0.1, 0.8, 0.5), kwargs...,
+    plotted_rect = poly!(
+        scene, rect, raw = true, visible = false, color = RGBAf0(0, 0, 0, 0), strokecolor = RGBAf0(0.1, 0.1, 0.8, 0.5), strokewidth = strokewidth, kwargs...,
     )[end] # Why do I have to do [end] ?
 
     on(events(scene).mousedrag) do drag

--- a/src/makielayout/lobjects/laxis.jl
+++ b/src/makielayout/lobjects/laxis.jl
@@ -438,7 +438,7 @@ end
 
 Set the target limits of `la` to an automatically determined rectangle, that depends
 on the data limits of all plot objects in the axis, as well as the autolimit margins
-for x and y axis. 
+for x and y axis.
 """
 function autolimits!(la::LAxis)
 
@@ -681,7 +681,10 @@ function add_zoom!(ax::LAxis)
             pa = pixelarea(scene)[]
 
             # don't let z go negative
-            z = max(0.1f0, 1f0 + (zoom * zoomspeed))
+            z = max(0.1f0, 1f0 - (abs(zoom) * zoomspeed))
+            if zoom > 0
+                z = 1/z   # sets the old to be a fraction of the new. This ensures zoom in & then out returns to original position.
+            end
 
             mp_axscene = Vec4f0((e.mouseposition[] .- pa.origin)..., 0, 1)
 

--- a/src/makielayout/lobjects/laxis.jl
+++ b/src/makielayout/lobjects/laxis.jl
@@ -721,6 +721,12 @@ function add_zoom!(ax::LAxis)
 
         return
     end
+
+    # Also support rubber band selection
+    rect = select_rectangle(scene)
+    on(rect) do r
+        tlimits[] = r
+    end
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,8 @@ using MeshIO, FileIO, AbstractPlotting.MakieLayout
     @test true
 end
 
+include("zoom_pan.jl")
+
 @testset "Minimal AbstractPlotting tests" begin
 
     include("conversions.jl")

--- a/test/zoom_pan.jl
+++ b/test/zoom_pan.jl
@@ -78,7 +78,6 @@ end
     end
 
     # Rubber band selection
-    # ax, axbox, lim, e = cleanaxes()
     scene, layout = layoutscene()
     ax = layout[1, 1] = LAxis(scene)
     plot!(ax, [10, 15, 20])
@@ -110,3 +109,20 @@ end
     @test all(lim.origin .>= newlim.origin) && all(lim.origin+lim.widths .<= newlim.origin+newlim.widths)
 end
 
+@testset "pan LAxis" begin
+    ax, axbox, lim, e = cleanaxes()
+    e.mouseposition[] = Tuple(axbox.origin + axbox.widths/2)
+    e.scroll[] = (0.0, -1.0)
+    newlim = ax.limits[]
+    e.mouseposition[] = Tuple(axbox.origin)
+    panbtn = ax.panbutton[]
+    e.mousebuttons[] = Set([panbtn])
+    e.mousedrag[] = Mouse.down
+    e.mouseposition[] = Tuple(axbox.origin + axbox.widths/10)
+    e.mousedrag[] = Mouse.pressed
+    e.mousebuttons[] = Set{typeof(panbtn)}()
+    e.mousedrag[] = Mouse.up
+    panlim = ax.limits[]
+    @test panlim.widths == newlim.widths
+    @test (5/4)*panlim.origin ≈ -newlim.origin
+end

--- a/test/zoom_pan.jl
+++ b/test/zoom_pan.jl
@@ -62,9 +62,9 @@ end
         lock[] = false
         # Simulate pressing the keys
         key = getproperty(ax, zoomkey)[]
-        buttons = getfield(e, AbstractPlotting.button_key(key))[]
-        @test isempty(buttons)
-        push!(buttons, key)
+        keypresses = getfield(e, AbstractPlotting.button_key(key))[]
+        @test isempty(keypresses)
+        push!(keypresses, key)
         e.scroll[] = (0.0, -1.0)
         newlim = ax.limits[]
         @test newlim.widths[idx] == lim.widths[idx]
@@ -77,6 +77,18 @@ end
         @test all(abs.(newlim.origin - lim.origin) .< 1e-7*lim.widths)
     end
 
+    # Rubber band selection
+    ax, axbox, lim, e = cleanaxes()
+    e.mouseposition[] = Tuple(axbox.origin)
+    e.mousebuttons[] = Set([Mouse.left])
+    e.mousedrag[] = Mouse.down
+    e.mouseposition[] = Tuple(axbox.origin + axbox.widths ./ Vec2(2, 3))
+    e.mousedrag[] = Mouse.pressed
+    e.mousebuttons[] = Set{typeof(Mouse.left)}()
+    e.mousedrag[] = Mouse.up
+    newlim = ax.limits[]
+    @test newlim.origin == lim.origin
+    @test newlim.widths ≈ lim.widths ./ Vec2(2, 3)
 
 end
 

--- a/test/zoom_pan.jl
+++ b/test/zoom_pan.jl
@@ -1,0 +1,82 @@
+using AbstractPlotting
+using AbstractPlotting.MakieLayout
+using Observables
+using Test
+
+function cleanaxes()
+    scene, layout = layoutscene()
+    ax = layout[1, 1] = LAxis(scene)
+    axbox = pixelarea(ax.scene)[]
+    lim = ax.limits[]
+    e = events(ax.scene)
+    return ax, axbox, lim, e
+end
+
+@testset "zoom LAxis" begin
+    ax, axbox, lim, e = cleanaxes()
+    # Put the mouse in the center
+    e.mouseposition[] = Tuple(axbox.origin + axbox.widths/2)
+    # zoom in
+    e.scroll[] = (0.0, -1.0)
+    newlim = ax.limits[]
+    @test newlim.widths ≈ 0.9 * lim.widths
+    @test newlim.origin ≈ lim.origin + (lim.widths - newlim.widths)/2
+    # zoom out restores original position
+    e.scroll[] = (0.0, 1.0)
+    newlim = ax.limits[]
+    @test newlim.widths ≈ lim.widths
+    @test all(abs.(newlim.origin - lim.origin) .< 1e-7*lim.widths)
+    ax.limits[] = lim
+    # Put mouse in corner
+    e.mouseposition[] = Tuple(axbox.origin)
+    # zoom in
+    e.scroll[] = (0.0, -1.0)
+    newlim = ax.limits[]
+    @test newlim.widths ≈ 0.9 * lim.widths
+    @test all(abs.(newlim.origin - lim.origin) .< 1e-7*lim.widths)
+    # zoom out
+    e.scroll[] = (0.0, 1.0)
+    newlim = ax.limits[]
+    @test newlim.widths ≈ lim.widths
+    @test all(abs.(newlim.origin - lim.origin) .< 1e-7*lim.widths)
+    ax.limits[] = lim
+
+    # Zoom only x or y
+    for (lockname, idx, zoomkey) in ((:xzoomlock, 1, :yzoomkey), (:yzoomlock, 2, :xzoomkey))
+        ax, axbox, lim, e = cleanaxes()
+        lock = getproperty(ax, lockname)
+        @test !lock[]
+        lock[] = true
+        e.mouseposition[] = Tuple(axbox.origin + axbox.widths/2)
+        e.scroll[] = (0.0, -1.0)
+        newlim = ax.limits[]
+        @test newlim.widths[idx] == lim.widths[idx]
+        @test newlim.widths[3-idx] ≈ 0.9 * lim.widths[3-idx]
+        @test newlim.origin[idx] == lim.origin[idx]
+        @test newlim.origin[3-idx] ≈ lim.origin[3-idx] + (lim.widths[3-idx] - newlim.widths[3-idx])/2
+        e.scroll[] = (0.0, 1.0)
+        newlim = ax.limits[]
+        @test newlim.widths ≈ lim.widths
+        @test all(abs.(newlim.origin - lim.origin) .< 1e-7*lim.widths)
+        ax.limits[] = lim
+        lock[] = false
+        # Simulate pressing the keys
+        key = getproperty(ax, zoomkey)[]
+        buttons = getfield(e, AbstractPlotting.button_key(key))[]
+        @test isempty(buttons)
+        push!(buttons, key)
+        e.scroll[] = (0.0, -1.0)
+        newlim = ax.limits[]
+        @test newlim.widths[idx] == lim.widths[idx]
+        @test newlim.widths[3-idx] ≈ 0.9 * lim.widths[3-idx]
+        @test newlim.origin[idx] == lim.origin[idx]
+        @test newlim.origin[3-idx] ≈ lim.origin[3-idx] + (lim.widths[3-idx] - newlim.widths[3-idx])/2
+        e.scroll[] = (0.0, 1.0)
+        newlim = ax.limits[]
+        @test newlim.widths ≈ lim.widths
+        @test all(abs.(newlim.origin - lim.origin) .< 1e-7*lim.widths)
+    end
+
+
+end
+

--- a/test/zoom_pan.jl
+++ b/test/zoom_pan.jl
@@ -78,7 +78,14 @@ end
     end
 
     # Rubber band selection
-    ax, axbox, lim, e = cleanaxes()
+    # ax, axbox, lim, e = cleanaxes()
+    scene, layout = layoutscene()
+    ax = layout[1, 1] = LAxis(scene)
+    plot!(ax, [10, 15, 20])
+    axbox = pixelarea(ax.scene)[]
+    lim = ax.limits[]
+    e = events(ax.scene)
+
     e.mouseposition[] = Tuple(axbox.origin)
     e.mousebuttons[] = Set([Mouse.left])
     e.mousedrag[] = Mouse.down
@@ -87,8 +94,19 @@ end
     e.mousebuttons[] = Set{typeof(Mouse.left)}()
     e.mousedrag[] = Mouse.up
     newlim = ax.limits[]
-    @test newlim.origin == lim.origin
+    @test newlim.origin ≈ lim.origin
     @test newlim.widths ≈ lim.widths ./ Vec2(2, 3)
-
+    # Ctrl-click to restore
+    key = AbstractPlotting.Keyboard.left_control
+    keypresses = e.keyboardbuttons[]
+    @test isempty(keypresses)
+    push!(keypresses, key)
+    buttons = e.mousebuttons[]
+    @test isempty(buttons)
+    e.mousebuttons[] = Set([Mouse.left])
+    empty!(e.mousebuttons[])
+    empty!(keypresses)
+    newlim = ax.limits[]
+    @test all(lim.origin .>= newlim.origin) && all(lim.origin+lim.widths .<= newlim.origin+newlim.widths)
 end
 


### PR DESCRIPTION
This turns on selection-zoom (rubber band selection) for LAxis. It also ensures that if you zoom in and then zoom out you get back to where you started. Formerly we got to 0.9*1.1 == 0.99, this changes it to 0.9 * (1/0.9) == 1.0.

Also, formerly the rubber band was not being drawn. I'm guessing there was an API change so that `lines!(ax, ::Rect)` no longer traces the boundary of the rectangle. I changed it to `poly!`, but let me know if there's a different preferred strategy.

Fixes https://github.com/JuliaPlots/Makie.jl/issues/728