### PR TITLE
Clearer docstring for `rotate_cam!`

### DIFF
--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -252,7 +252,8 @@ end
     rotate_cam!(scene::Scene, theta_v::Number...)
     rotate_cam!(scene::Scene, theta_v::VecTypes)
 
-Rotate the camera of the Scene by the given rotation.
+Rotate the camera of the Scene by the given rotation. Passing `theta_v = (α, β, γ)` will rotate
+the camera according to the Euler angles (α, β, γ).
 """
 rotate_cam!(scene::Scene, theta_v::Number...) = rotate_cam!(scene, cameracontrols(scene), theta_v)
 rotate_cam!(scene::Scene, theta_v::VecTypes) = rotate_cam!(scene, cameracontrols(scene), theta_v)


### PR DESCRIPTION
Initially tried calling `rotate_cam!(scene::Scene, 0.1)` when I meant `rotate_cam!(scene::Scene, (0.1, 0, 0))` so just opening a PR to make the docstring a bit clearer.

Wanted to say pitch, yaw, roll but wasn't sure which angled corresponded to which haha.