### PR TITLE
Fix problems with empty plots / strings / annotations / tick labels

### DIFF
--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -75,6 +75,8 @@ end
 
 function glyph_positions(str::AbstractString, font_per_char, fontscale_px, halign, valign, lineheight_factor, justification)
 
+    isempty(str) && return Vec2f0[]
+
     char_font_scale = collect(zip([c for c in str], font_per_char, fontscale_px))
 
     linebreak_indices = (i for (i, c) in enumerate(str) if c == '\n')
@@ -108,8 +110,11 @@ function glyph_positions(str::AbstractString, font_per_char, fontscale_px, halig
 
     # make lineheight a multiple of the largest lineheight in each line
     lineheights = map(cfs_groups) do group
+        # guard from empty reduction
+        isempty(group) && return 0f0
+        
         maximum(group) do (char, font, scale)
-            font.height / font.units_per_EM * lineheight_factor * scale
+            Float32(font.height / font.units_per_EM * lineheight_factor * scale)
         end
     end
 

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -14,11 +14,11 @@ end
 function default_attributes(::Type{LAxis}, scene)
     attrs, docdict, defaultdict = @documented_attributes begin
         "The xlabel string."
-        xlabel = " "
+        xlabel = ""
         "The ylabel string."
-        ylabel = " "
+        ylabel = ""
         "The axis title string."
-        title = " "
+        title = ""
         "The font family of the title."
         titlefont = lift_parent_attribute(scene, :font, "DejaVu Sans")
         "The title's font size."
@@ -218,7 +218,7 @@ LAxis
 function default_attributes(::Type{LColorbar}, scene)
     attrs, docdict, defaultdict = @documented_attributes begin
         "The color bar label string."
-        label = " "
+        label = ""
         "The label color."
         labelcolor = RGBf0(0, 0, 0)
         "The label font family."

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -255,13 +255,14 @@ function LineAxis(parent::Scene; kwargs...)
 
         position, extents, horizontal = pos_extents_horizontal[]
 
-        real_labelsize = if iswhitespace(label)
+        label_is_empty = iswhitespace(label) || isempty(label)
+        real_labelsize = if label_is_empty
             0f0
         else
             horizontal ? boundingbox(labeltext).widths[2] : boundingbox(labeltext).widths[1]
         end
 
-        labelspace = (labelvisible && !iswhitespace(label)) ? real_labelsize + labelpadding : 0f0
+        labelspace = (labelvisible && !label_is_empty) ? real_labelsize + labelpadding : 0f0
         # tickspace = ticksvisible ? max(0f0, xticksize * (1f0 - xtickalign)) : 0f0
         ticklabelgap = ticklabelsvisible ? actual_ticklabelspace + ticklabelpad : 0f0
 

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -54,6 +54,11 @@ function LineAxis(parent::Scene; kwargs...)
                 # width
                 ticklabelsvisible[] ? width(FRect2D(boundingbox(ticklabels))) : 0f0
         end
+        # in case there is no string in the annotations and the boundingbox comes back all NaN
+        if !isfinite(maxwidth)
+            maxwidth = zero(maxwidth)
+        end
+        maxwidth
     end
 
     attrs[:actual_ticklabelspace] = 0f0

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -264,7 +264,9 @@ function LineAxis(parent::Scene; kwargs...)
 
         labelspace = (labelvisible && !label_is_empty) ? real_labelsize + labelpadding : 0f0
         # tickspace = ticksvisible ? max(0f0, xticksize * (1f0 - xtickalign)) : 0f0
-        ticklabelgap = ticklabelsvisible ? actual_ticklabelspace + ticklabelpad : 0f0
+        tickspace = (ticksvisible && !isempty(ticklabelannosnode[])) ? tickspace : 0f0
+
+        ticklabelgap = (ticklabelsvisible && actual_ticklabelspace > 0) ? actual_ticklabelspace + ticklabelpad : 0f0
 
         together = tickspace + ticklabelgap + labelspace
     end

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -34,7 +34,7 @@ function LineAxis(parent::Scene; kwargs...)
     )[end]
     decorations[:ticklines] = ticklines
 
-    ticklabelannosnode = Node{Vector{Tuple{String, Point2f0}}}([("temp", Point2f0(0, 0))])
+    ticklabelannosnode = Node(Tuple{String, Point2f0}[])
     ticklabels = annotations!(
         parent,
         ticklabelannosnode,

--- a/src/makielayout/lobjects/laxis.jl
+++ b/src/makielayout/lobjects/laxis.jl
@@ -369,19 +369,26 @@ function getlimits(la::LAxis, dim)
         filter(p -> !haskey(p.attributes, :xautolimits) || p.attributes.xautolimits[], la.scene.plots)
     elseif dim == 2
         filter(p -> !haskey(p.attributes, :yautolimits) || p.attributes.yautolimits[], la.scene.plots)
+    else
+        error("Dimension $dim not allowed. Only 1 or 2.")
     end
 
-    lim = if length(plots_with_autolimits) > 0
-        bbox = FRect2D(AbstractPlotting.data_limits(plots_with_autolimits[1]))
-        templim = (bbox.origin[dim], bbox.origin[dim] + bbox.widths[dim])
-        for p in plots_with_autolimits[2:end]
-            bbox = FRect2D(AbstractPlotting.data_limits(p))
-            templim = limitunion(templim, (bbox.origin[dim], bbox.origin[dim] + bbox.widths[dim]))
-        end
-        templim
-    else
-        nothing
+    visible_plots = filter(
+        p -> !haskey(p.attributes, :visible) || p.attributes.visible[],
+        plots_with_autolimits)
+
+    bboxes = [FRect2D(AbstractPlotting.data_limits(p)) for p in visible_plots]
+    finite_bboxes = filter(isfinite, bboxes)
+
+    isempty(finite_bboxes) && return nothing
+
+    templim = (finite_bboxes[1].origin[dim], finite_bboxes[1].origin[dim] + finite_bboxes[1].widths[dim])
+
+    for bb in finite_bboxes[2:end]
+        templim = limitunion(templim, (bb.origin[dim], bb.origin[dim] + bb.widths[dim]))
     end
+
+    templim
 end
 
 getxlimits(la::LAxis) = getlimits(la, 1)

--- a/src/makielayout/lobjects/laxis.jl
+++ b/src/makielayout/lobjects/laxis.jl
@@ -263,7 +263,9 @@ function LAxis(parent::Scene; bbox = nothing, kwargs...)
         titlespace = if !titlevisible || iswhitespace(title)
             0f0
         else
-            boundingbox(titlet).widths[2] + titlegap
+            ts = boundingbox(titlet).widths[2] + titlegap
+            # guard against empty title string
+            isfinite(ts) ? ts : 0f0
         end
         top += titlespace
 

--- a/src/makielayout/lobjects/laxis.jl
+++ b/src/makielayout/lobjects/laxis.jl
@@ -260,12 +260,10 @@ function LAxis(parent::Scene; bbox = nothing, kwargs...)
             top = xaxisprotrusion
         end
 
-        titlespace = if !titlevisible || iswhitespace(title)
+        titlespace = if !titlevisible || iswhitespace(title) || isempty(title)
             0f0
         else
-            ts = boundingbox(titlet).widths[2] + titlegap
-            # guard against empty title string
-            isfinite(ts) ? ts : 0f0
+            boundingbox(titlet).widths[2] + titlegap
         end
         top += titlespace
 

--- a/src/makielayout/ticklocators/linear.jl
+++ b/src/makielayout/ticklocators/linear.jl
@@ -74,6 +74,10 @@ A cheaper function that tries to come up with usable tick locations for a given 
 """
 function locateticks(vmin, vmax, n_ideal::Int, _integer::Bool = false, _min_n_ticks::Int = 2)
 
+    @assert isfinite(vmin)
+    @assert isfinite(vmax)
+    @assert vmin != vmax
+
     _steps = (1.0, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0)
     _extended_steps = _staircase(_steps)
 

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -148,10 +148,16 @@ Like broadcast but for foreach. Doesn't care about shape and treats Tuples && St
 function broadcast_foreach(f, args...)
     lengths = bs_length.(args)
     maxlen = maximum(lengths)
+
     # all non scalars should have same length
     if any(x -> !(x in (0, 1, maxlen)), lengths)
         error("All non scalars need same length, Found lengths for each argument: $lengths, $(typeof.(args))")
     end
+
+    # skip if there's a zero length element (like an empty annotations collection, etc)
+    # this differs from standard broadcasting logic in which all non-scalar shapes have to match
+    0 in lengths && return
+
     for i in 1:maxlen
         f(bs_getindex.(args, i)...)
     end


### PR DESCRIPTION
The most important change is that `broadcast_foreach` does zero iterations if one element is zero length. So far, it always tried one iteration, which would fail with zero-length containers like empty annotations etc.

Then a couple places needed guards against the NaN limits that come from such empty plots usually. In the course of that, LAxis only accepts visible non NaN limits to contribute to autolimits.

`text` also couldn't deal with empty strings because of layouting issues, which it now can. LAxis checks against empty titles and xlabels / ylabels and can now receive empty strings for those attributes.