### PR TITLE
Fix `delete!` bug

### DIFF
--- a/src/makielayout/helpers.jl
+++ b/src/makielayout/helpers.jl
@@ -319,7 +319,7 @@ function Base.delete!(lobject::Union{LObject, LAxis})
         remove_element(d)
     end
 
-    if hasfield(typeof(lobject), :scene)
+    if Base.hasfield(typeof(lobject), :scene)
         delete_scene!(lobject.scene)
     end
 


### PR DESCRIPTION
If I try to delete a legend, I get
```julia
MethodError: no method matching hasfield(::Type{AbstractPlotting.MakieLayout.LLegend}, ::Symbol)

You may have intended to import Base.hasfield

delete!(::AbstractPlotting.MakieLayout.LLegend)@helpers.jl:322
top-level scope@Local: 10
```
And if I monkey-patch AbstractPlotting.MakieLayout via
```julia
@eval MakieLayout begin
	function Base.delete!(lobject::Union{LObject, LAxis})
		for (_, d) in lobject.decorations
			remove_element(d)
		end

		if Base.hasfield(typeof(lobject), :scene)
			delete_scene!(lobject.scene)
		end

		GridLayoutBase.remove_from_gridlayout!(GridLayoutBase.gridcontent(lobject))
		return nothing
	end
end
```
it works.