### PR TITLE
Added option of toggling rubber-band zooming

### DIFF
--- a/src/interaction/interactive_api.jl
+++ b/src/interaction/interactive_api.jl
@@ -146,7 +146,7 @@ rectangle has area > 0.
 
 The `kwargs...` are propagated into `lines!` which plots the selected rectangle.
 """
-function select_rectangle(scene; strokewidth = 3.0, kwargs...)
+function select_rectangle(scene, enabled=Node(true); strokewidth = 3.0, kwargs...)
     key = Mouse.left
     waspressed = Node(false)
     rect = Node(FRect(0, 0, 1, 1)) # plotted rectangle
@@ -157,8 +157,11 @@ function select_rectangle(scene; strokewidth = 3.0, kwargs...)
         scene, rect, raw = true, visible = false, color = RGBAf0(0, 0, 0, 0), strokecolor = RGBAf0(0.1, 0.1, 0.8, 0.5), strokewidth = strokewidth, kwargs...,
     )[end] # Why do I have to do [end] ?
 
-    on(events(scene).mousedrag) do drag
-        if ispressed(scene, key) && is_mouseinside(scene)
+    onany(events(scene).mousedrag, enabled) do drag, is_enabled
+        if !is_enabled
+            plotted_rect[:visible] = false
+            waspressed[] = false
+        elseif ispressed(scene, key) && is_mouseinside(scene)
             mp = mouseposition(scene)
             if drag == Mouse.down
                 waspressed[] = true

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -200,6 +200,8 @@ function default_attributes(::Type{LAxis}, scene)
         yreversed = false
         "Controls if the x axis goes rightwards (false) or leftwards (true)"
         xreversed = false
+        "Enables rubber-band zooming by drawing a rectangle"
+        rubberband = false
     end
 
     (attributes = attrs, documentation = docdict, defaults = defaultdict)

--- a/src/makielayout/lobjects/laxis.jl
+++ b/src/makielayout/lobjects/laxis.jl
@@ -31,7 +31,7 @@ function LAxis(parent::Scene; bbox = nothing, kwargs...)
         bottomspinecolor, leftspinecolor, topspinecolor, rightspinecolor,
         backgroundcolor,
         xlabelfont, ylabelfont, xticklabelfont, yticklabelfont,
-        flip_ylabel, xreversed, yreversed,
+        flip_ylabel, xreversed, yreversed, rubberband
     )
 
     decorations = Dict{Symbol, Any}()
@@ -730,9 +730,11 @@ function add_zoom!(ax::LAxis)
     end
 
     # Also support rubber band selection
-    rect = select_rectangle(scene)
+    rect = select_rectangle(scene, ax.rubberband)
     on(rect) do r
-        tlimits[] = r
+        if ax.rubberband[]
+            tlimits[] = r
+        end
     end
 end
 


### PR DESCRIPTION
The currently-default, always-on rubber band LAxis zoom (introduced in a recent commit) breaks many interactive applications. I added an attribute to be able to disable it. It involves a slightly inelegant addition in `select_rectangle`, but I think it's a working stopgap solution until a more comprehensive framework for interactive tools is implemented (akin to matplotlib or plotly's tool bar)