### PR TITLE
added a visible attribute to BarPlot

### DIFF
--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -17,6 +17,7 @@ $(ATTRIBUTES)
         strokecolor = :white,
         width = automatic,
         direction = :y,
+        visible = theme(scene, :visible),
     )
 end
 
@@ -58,6 +59,6 @@ function AbstractPlotting.plot!(p::BarPlot)
 
     poly!(
         p, bars, color = p.color, colormap = p.colormap, colorrange = p.colorrange,
-        strokewidth = p.strokewidth, strokecolor = p.strokecolor
+        strokewidth = p.strokewidth, strokecolor = p.strokecolor, visible = p.visible
     )
 end


### PR DESCRIPTION
This just adds a `visible` attribute to `BarPlot`. It looks like some other compound plot types in basic_recipes (e.g. `Contour`?) could use that too but I am not familiar enough with those atm.

Related issue: JuliaPlots/Makie.jl#744