### PR TITLE
Don't shadow `hasfield`

### DIFF
--- a/src/makielayout/lobjects/lobject.jl
+++ b/src/makielayout/lobjects/lobject.jl
@@ -6,7 +6,7 @@ const Layoutable = Union{LAxis, LScene, LObject}
 # make fields type inferrable
 # just access attributes directly instead of via indexing detour
 
-@generated hasfield(x::T, ::Val{key}) where {T<:Layoutable, key} = :($(key in fieldnames(T)))
+@generated Base.hasfield(x::T, ::Val{key}) where {T<:Layoutable, key} = :($(key in fieldnames(T)))
 
 @inline function Base.getproperty(x::T, key::Symbol) where T <: Layoutable
     if hasfield(x, Val(key))


### PR DESCRIPTION
Alternate fix to https://github.com/JuliaPlots/AbstractPlotting.jl/pull/535 as suggested by @SimonDanisch 