### PR TITLE
Make texture atlas serialization julia-version specific

### DIFF
--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -52,7 +52,7 @@ begin
     function get_cache_path()
         return abspath(
             first(Base.DEPOT_PATH), "makiegallery", ".cache",
-            "texture_atlas_$(CACHE_RESOLUTION_PREFIX[]).jls"
+            "texture_atlas_$(CACHE_RESOLUTION_PREFIX[])_$(VERSION).jls"
         )
     end
 


### PR DESCRIPTION
Seems like a good idea? Especially for people switching between julia versions