### PR TITLE
[WIP] Update interaction functions select_thing to new registration pipeline

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractPlotting"
 uuid = "537997a7-5e4e-5d89-9595-2241ea00577e"
 authors = ["Simon Danisch", "Julius Krumbiegel"]
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"

--- a/src/interaction/interactive_api.jl
+++ b/src/interaction/interactive_api.jl
@@ -133,7 +133,7 @@ Properly identifies the scene for a plot with multiple sub-plots.
 hovered_scene() = error("hoevered_scene is not implemented yet.")
 
 """
-    select_rectangle(scene; kwargs...) -> rect
+    select_rectangle(laxis_or_scene; kwargs...) -> rect
 Interactively select a rectangle on a 2D `scene` by clicking the left mouse button,
 dragging and then un-clicking. The function returns an **observable** `rect` whose
 value corresponds to the selected rectangle on the scene. In addition the function
@@ -145,6 +145,9 @@ The value of the returned observable is updated **only** when the user un-clicks
 rectangle has area > 0.
 
 The `kwargs...` are propagated into `lines!` which plots the selected rectangle.
+
+If called on an `::LAxis`, the interaction is properly registered through the
+interaction registration pipeline.
 """
 function select_rectangle(scene; strokewidth = 3.0, kwargs...)
     key = Mouse.left

--- a/src/interaction/interactive_api.jl
+++ b/src/interaction/interactive_api.jl
@@ -146,8 +146,7 @@ rectangle has area > 0.
 
 The `kwargs...` are propagated into `lines!` which plots the selected rectangle.
 
-If called on an `::LAxis`, the interaction is properly registered through the
-interaction registration pipeline.
+If called on an `::LAxis`, it disables the click+drag+zoom default functionality.
 """
 function select_rectangle(scene; strokewidth = 3.0, kwargs...)
     key = Mouse.left
@@ -201,8 +200,7 @@ and only if the selected line has non-zero length.
 
 The `kwargs...` are propagated into `lines!` which plots the selected line.
 
-If called on an `::LAxis`, the interaction is properly registered through the
-interaction registration pipeline.
+If called on an `::LAxis`, it disables the click+drag+zoom default functionality.
 """
 function select_line(scene; kwargs...)
     key = Mouse.left
@@ -255,8 +253,7 @@ The value of the returned point is updated **only** when the user un-clicks.
 
 The `kwargs...` are propagated into `scatter!` which plots the selected point.
 
-If called on an `::LAxis`, the interaction is properly registered through the
-interaction registration pipeline.
+If called on an `::LAxis`, it disables the click+drag+zoom default functionality.
 """
 function select_point(scene; kwargs...)
     key = Mouse.left

--- a/src/interaction/interactive_api.jl
+++ b/src/interaction/interactive_api.jl
@@ -189,7 +189,7 @@ function select_rectangle(scene; strokewidth = 3.0, kwargs...)
 end
 
 """
-    select_line(scene; kwargs...) -> line
+    select_line(laxis_or_scene; kwargs...) -> line
 Interactively select a line (typically an arrow) on a 2D `scene` by clicking the left mouse button,
 dragging and then un-clicking. Return an **observable** whose value corresponds
 to the selected line on the scene. In addition the function
@@ -200,6 +200,9 @@ The value of the returned line is updated **only** when the user un-clicks
 and only if the selected line has non-zero length.
 
 The `kwargs...` are propagated into `lines!` which plots the selected line.
+
+If called on an `::LAxis`, the interaction is properly registered through the
+interaction registration pipeline.
 """
 function select_line(scene; kwargs...)
     key = Mouse.left
@@ -241,7 +244,7 @@ function select_line(scene; kwargs...)
 end
 
 """
-    select_point(scene; kwargs...) -> point
+    select_point(laxis_or_scene; kwargs...) -> point
 Interactively select a point on a 2D `scene` by clicking the left mouse button,
 dragging and then un-clicking. Return an **observable** whose value corresponds
 to the selected point on the scene. In addition the function
@@ -251,6 +254,9 @@ around. When the button is not clicked any more, the plotted point disappears.
 The value of the returned point is updated **only** when the user un-clicks.
 
 The `kwargs...` are propagated into `scatter!` which plots the selected point.
+
+If called on an `::LAxis`, the interaction is properly registered through the
+interaction registration pipeline.
 """
 function select_point(scene; kwargs...)
     key = Mouse.left

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -109,11 +109,11 @@ function _chosen_limits(rz, ax)
     lims = ax.limits[]
     # restrict to y change
     if rz.restrict_x || !ax.xrectzoom[]
-        r = FRect2D(lims.origin[1], r.origin[2], widths(lims)[1], widths(r)[2]) 
+        r = FRect2D(lims.origin[1], r.origin[2], widths(lims)[1], widths(r)[2])
     end
     # restrict to x change
     if rz.restrict_y || !ax.yrectzoom[]
-        r = FRect2D(r.origin[1], lims.origin[2], widths(r)[1], widths(lims)[2]) 
+        r = FRect2D(r.origin[1], lims.origin[2], widths(r)[1], widths(lims)[2])
     end
     return r
 end
@@ -298,6 +298,14 @@ function process_interaction(dp::DragPan, event::MouseEvent, ax)
     timed_ticklabelspace_reset(ax, dp.reset_timer, dp.prev_xticklabelspace, dp.prev_yticklabelspace, dp.reset_delay)
 
     tlimits[] = FRect(Vec2f0(xori, yori), widths(tlimits[]))
-           
+
     return nothing
+end
+
+############################################################################
+#             Interactions that return values when activated               #
+############################################################################
+function AbstractPlotting.select_rectangle(ax::MakieLayout.LAxis; kwargs...)
+    deactivate_interaction!(ax, :rectanglezoom)
+    select_rectangle(ax.scene; kwargs...)
 end

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -309,3 +309,17 @@ function AbstractPlotting.select_rectangle(ax::MakieLayout.LAxis; kwargs...)
     deactivate_interaction!(ax, :rectanglezoom)
     select_rectangle(ax.scene; kwargs...)
 end
+
+function AbstractPlotting.select_line(ax::MakieLayout.LAxis; kwargs...)
+    deactivate_interaction!(ax, :rectanglezoom)
+    select_line(ax.scene; kwargs...)
+end
+
+# For select point, technically it is not necessary to remove the rectanglezoom
+# interaction, however, I've found out that even the slightest mouse movement
+# while selecting a point will case the plot to zoom in aribtrarily.
+# Thus it is better to disable and use mousewheel to zoom
+function AbstractPlotting.select_point(ax::MakieLayout.LAxis; kwargs...)
+    deactivate_interaction!(ax, :rectanglezoom)
+    select_point(ax.scene; kwargs...)
+end


### PR DESCRIPTION
I'm taking baby steps here because I'm a new comer. The goal of this PR is to slowly update the functions `select_line, select_rectangle, select_point`, that I've contributed some time ago, to the new registration interaction API that Julius wrote.

To my knowledge these functions are used in InteractiveChaos.jl, but I don't think they're used anywhere else.

At the moment I'm starting with `select_rectangle` which was very easy to make it work. Now I need to make it properly implement the registration API.