### PR TITLE
fix Axis3D scaling issues

### DIFF
--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -221,7 +221,7 @@ function ticks!(scene=current_scene(); tickranges=tickranges(scene), ticklabels=
 end
 
 """
-    xticks!([scene,]; xtickranges=xtickrange(scene), xticklabels=xticklabel(scene))
+    xticks!([scene,]; xtickrange=xtickrange(scene), xticklabels=xticklabel(scene))
 
 Set the tick labels and range along the x-axes. See also `ticks!`.
 """
@@ -231,7 +231,7 @@ function xticks!(scene=current_scene(); xtickrange=xtickrange(scene), xticklabel
 end
 
 """
-    yticks!([scene,]; ytickranges=ytickrange(scene), yticklabels=yticklabel(scene))
+    yticks!([scene,]; ytickrange=ytickrange(scene), yticklabels=yticklabel(scene))
 
 Set the tick labels and range along all the y-axis. See also `ticks!`.
 """


### PR DESCRIPTION
Example from Slack:

```julia
using AbstractPlotting, GLMakie
x = rand(100).*260.0;
y = rand(100).*10000.0;
z = rand(100).*7400.0;
maxvals = map(a->maximum(a), [x,y,z]);
maxmax = maximum(maxvals);
scale_factors = map(a->maxmax/a, maxvals);
s2 = AbstractPlotting.Scene();
AbstractPlotting.scatter!(s2,x,y,z,markersize=500);
axes=s2[Axis];
axes[:names][:axisnames]=("East-west","North-south","Up down");
axes[:names][:textsize]=(200,200,200);
axes[:ticks][:textsize]=(120,120,120);
AbstractPlotting.scale!(s2,scale_factors[1],scale_factors[2],scale_factors[3]);
display(s2)
```

produces

![image](https://user-images.githubusercontent.com/10947937/100154764-693d3580-2ea6-11eb-9aff-9f63b8176c0d.png)

This pr fixes two things - the spacing of axis labels (via the `w / scale[j]`) and the gap between ticks (numbers) and axis lines in scaled plots. 

With this pr:

![Screenshot from 2020-11-24 22-38-53](https://user-images.githubusercontent.com/10947937/100155153-09935a00-2ea7-11eb-8cdc-04b8f6cb0590.png)
