### PR TITLE
Change _primary_resolution to use system calls on Apple computers

### DIFF
--- a/src/theming.jl
+++ b/src/theming.jl
@@ -8,10 +8,12 @@ if Sys.iswindows()
         end
     end
 elseif Sys.isapple()
+    const _CoreGraphics = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
     function _primary_resolution()
-        s = read(pipeline(`system_profiler SPDisplaysDataType`, `grep Resolution`)) |> String
-        sarr = split(s)
-        return parse.(Int, (sarr[2], sarr[4]))
+        dispid = ccall((:CGMainDisplayID, _CoreGraphics), UInt32,())
+        height = ccall((:CGDisplayPixelsHigh,_CoreGraphics), Int, (UInt32,), dispid)
+        width = ccall((:CGDisplayPixelsWide,_CoreGraphics), Int, (UInt32,), dispid)
+        return (width, height)
     end
 # elseif Sys.islinux()
 #     function _primary_resolution()

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -8,7 +8,7 @@ if Sys.iswindows()
         end
     end
 elseif Sys.isapple()
-    const _CoreGraphics = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+    const _CoreGraphics = "CoreGraphics.framework/CoreGraphics"
     function _primary_resolution()
         dispid = ccall((:CGMainDisplayID, _CoreGraphics), UInt32,())
         height = ccall((:CGDisplayPixelsHigh,_CoreGraphics), Int, (UInt32,), dispid)


### PR DESCRIPTION
This fixes primary_resolution() so that it returns that actual current display setting.   It also changes the call to use system calls which should be faster.