### PR TITLE
Update tutorial.md

### DIFF
--- a/docs/src/makielayout/tutorial.md
+++ b/docs/src/makielayout/tutorial.md
@@ -14,7 +14,7 @@ All right, let's get started!
 
 ## Scene and Layout
 
-First, we import CairoMakie, which brings in AbstractPlotting and MakieLayout as well.
+First, we import CairoMakie, which brings in AbstractPlotting, and MakieLayout.
 Then we create the main scene and layout.
 The function `layoutscene` is a convenience function that creates a `Scene`
 which has a `GridLayout` attached to it that always fills the whole scene area.
@@ -22,6 +22,7 @@ You can pass the outer padding of the top layout as the first argument.
 
 ```@example tutorial
 using CairoMakie
+using MakieLayout
 using Random # hide
 Random.seed!(2) # hide
 
@@ -275,6 +276,7 @@ two axes at once. The number of cells and objects has to match to do this.
 hm_axes = layout[1:2, 3] = [LAxis(scene, title = t) for t in ["Cell Assembly Pre", "Cell Assembly Post"]]
 
 heatmaps = [heatmap!(ax, i .+ rand(20, 20)) for (i, ax) in enumerate(hm_axes)]
+[limits!(hm_ax, 0, 20, 0, 20) for hm_ax in hm_axes] # Setting limits for axes: x1, x2, y1, y2
 
 scene
 save("step_013.svg", scene) # hide


### PR DESCRIPTION
Was trying to go through the tutorial for MakieLayout and got some comments/proposes:

**1) CairoMakie does not bring MakieLayout**

I had to import `MakieLayout` to get `layoutscene()`. But considering the warning raised from importing `MakieLayout`:

```
┌ Warning: MakieLayout.jl has been absorbed by AbstractPlotting.jl and will not receive any more updates.
│ It is enough to install AbstractPlotting to receive the newest functionality.
│ Visit the Makie docs at http://makie.juliaplots.org/ for more information on how to use it.
└ @ MakieLayout C:\Users\Benjamin\.julia\packages\MakieLayout\qJ2me\src\MakieLayout.jl:27
```

I propose adding `using MakieLayout` until dependencies have been corrected so the tutorial is at least possible to go through. I guess `layoutscene` and `RGBf0` must be included in AbstractPlotting?

**2) Sublayouts: The heatmaps are not limited from 0 to 20 as in the figure**
I can understand that there is [some discussion](https://github.com/JuliaPlots/Makie.jl/issues/118) on how to define limits of a plot. I could not manage to do this within `heatmaps!()`, which is reason for adding:

```
[limits!(hm_ax, 0, 20, 0, 20) for hm_ax in hm_axes]
```
