### PR TITLE
Make button color updates take effect immediately

### DIFF
--- a/src/makielayout/layoutables/button.jl
+++ b/src/makielayout/layoutables/button.jl
@@ -36,15 +36,18 @@ function Button(fig_or_scene::FigureLike; bbox = nothing, kwargs...)
 
     roundedrectpoints = lift(roundedrectvertices, buttonrect, cornerradius, cornersegments)
 
-    bcolor = Node{Any}(buttoncolor[])
+    mousestate = Node(:out)
+
+    bcolors = (; out = buttoncolor, active = buttoncolor_active, hover = buttoncolor_hover)
+    bcolor = lift((s,_...)->bcolors[s][], mousestate, values(bcolors)...; typ=Any)
     button = poly!(subscene, roundedrectpoints, strokewidth = strokewidth, strokecolor = strokecolor,
         color = bcolor, raw = true)
     decorations[:button] = button
 
 
 
-
-    lcolor = Node{Any}(labelcolor[])
+    lcolors = (; out = labelcolor, active = labelcolor_active, hover = labelcolor_hover)
+    lcolor = lift((s,_...)->lcolors[s][], mousestate, values(lcolors)...; typ=Any)
     labeltext = text!(subscene, label, position = textpos, textsize = textsize, font = font,
         color = lcolor, align = (:center, :center), raw = true)
 
@@ -65,24 +68,20 @@ function Button(fig_or_scene::FigureLike; bbox = nothing, kwargs...)
 
     mouseevents = addmouseevents!(scene, button, labeltext)
 
-    onmouseover(mouseevents) do state
-        bcolor[] = buttoncolor_hover[]
-        lcolor[] = labelcolor_hover[]
+    onmouseover(mouseevents) do _
+        mousestate[] = :hover
     end
 
-    onmouseout(mouseevents) do state
-        bcolor[] = buttoncolor[]
-        lcolor[] = labelcolor[]
+    onmouseout(mouseevents) do _
+        mousestate[] = :out
+    end
+    
+    onmouseleftup(mouseevents) do _
+        mousestate[] = :hover
     end
 
-    onmouseleftup(mouseevents) do state
-        bcolor[] = buttoncolor_hover[]
-        lcolor[] = labelcolor_hover[]
-    end
-
-    onmouseleftdown(mouseevents) do state
-        bcolor[] = buttoncolor_active[]
-        lcolor[] = labelcolor_active[]
+    onmouseleftdown(mouseevents) do _
+        mousestate[] = :active
         clicks[] = clicks[] + 1
     end
 


### PR DESCRIPTION
This makes update such as `button.buttoncolor = ...` show immediately rather than on the next mouse event on the button.
Demo script for testing:
```
scene, layout = layoutscene()
default_sl = layout[1,1] = LSlider(scene; range=0:0.1:1)

b = layout[2,1] = LButton(scene)
on(default_sl.value) do v
    b.buttoncolor = Gray(v)
    b.labelcolor = Gray(1-v)
end
on(scene.events.keyboardbuttons) do button
    if ispressed(button, Keyboard.space)
        for sym in (:buttoncolor_hover, :buttoncolor_active, :labelcolor_hover, :labelcolor_active)
            b.:($sym) = rand(RGBf0)
        end
    end
end
scene
```