### PR TITLE
Precompilation docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -367,6 +367,7 @@ makedocs(
             "backends.md",
             "troubleshooting.md",
             "API Reference AbstractPlotting" => "abstractplotting_api.md",
+            "precompilation.md",
         ],
         "MakieLayout" => [
             "Tutorial" => "makielayout/tutorial.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,6 +28,7 @@ CairoMakie.activate!()
 - Learn the basics of plotting with Makie in the [Tutorial](@ref)
 - Check out how to make more complex plots and layouts in the [MakieLayout Tutorial](@ref)
 - See example plots in the [Gallery](http://juliaplots.org/MakieReferenceImages/gallery/index.html).
+- Speed up time to first plot by learning about [Precompilation](@ref)
 
 
 ## Makie Ecosystem

--- a/docs/src/precompilation.md
+++ b/docs/src/precompilation.md
@@ -1,0 +1,24 @@
+## Precompilation
+
+You can compile a binary for Makie and add it to your system image for fast plotting times with no JIT overhead.
+To do that, you need to check out the additional packages for precompilation.
+Then you can build a system image like this:
+
+```julia
+using Pkg
+# add PackageCompiler and other dependencies
+pkg"add PackageCompiler"
+# Make sure you have v1.0 or higher of PackageCompiler!
+
+using PackageCompiler
+
+# This will create a system image in the current directory, which you can
+# use by launching Julia with `julia -J ./MakieSys.so`.
+PackageCompiler.create_sysimage(
+    :Makie;
+    sysimage_path="MakieSys.so",
+    precompile_execution_file=joinpath(pkgdir(Makie), "test", "test_for_precompile.jl")
+)
+```
+
+Should the display not work after compilation, call `AbstractPlotting.__init__()` immediately after `using Makie`.


### PR DESCRIPTION
It looks like the bit about precompilation using PackageCompiler didn't get transferred from Makie.jl to AbstractPlotting.jl. This PR just copies that onto a separate page in the docs and links there from the home page.