### PR TITLE
improve linestyles, add "-.-." and (:dash, :loose) variants

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 UnicodeFun = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -41,6 +41,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 UnicodeFun = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 
 [compat]

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -741,10 +741,8 @@ end
 
 "Checks if the linestyle format provided as a string contains only dashes and dots"
 function check_pattern(ls_str)
-    for i in 1:length(ls_str)
-        ls_str[i] == '-' || ls_str[i] == '.' ||
+    isnothing(match(r"^[\.\-]+$", ls_str)) &&
         throw(ArgumentError("If you provide a string as linestyle, it must only consist of dashes (-) and dots (.)"))
-    end
 end
 
 function convert_gaps(gaps)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -680,19 +680,8 @@ convert_attribute(A::AbstractVector, ::key"linestyle") = A
 function convert_attribute(ls::Symbol, ::key"linestyle")
     return if ls == :solid
         nothing
-    elseif ls == :dash
-        [0.0, 1.0, 2.0, 3.0, 4.0]
-    elseif ls == :dot
-        tick, gap = 1/2, 1/4
-        [0.0, tick, tick+gap, 2tick+gap, 2tick+2gap]
-    elseif ls == :dashdot
-        dtick, dgap = 1.0, 1.0
-        ptick, pgap = 1/2, 1/4
-        [0.0, dtick, dtick+dgap, dtick+dgap+ptick, dtick+dgap+ptick+pgap]
-    elseif ls == :dashdotdot
-        dtick, dgap = 1.0, 1.0
-        ptick, pgap = 1/2, 1/4
-        [0.0, dtick, dtick+dgap, dtick+dgap+ptick, dtick+dgap+ptick+pgap, dtick+dgap+ptick+pgap+ptick,  dtick+dgap+ptick+pgap+ptick+pgap]
+    elseif ls in [:dash, :dot, :dashdot, :dashdotdot]
+        pattern(ls)
     else
         error(
             """
@@ -702,6 +691,32 @@ function convert_attribute(ls::Symbol, ::key"linestyle")
             This sequence of numbers must be cumulative; 1 unit corresponds to 1 line width.
             """
         )
+    end
+end
+
+function pattern(linestyle, modifier=:normal; kwargs...)
+    float.([0; cumsum(_pattern(linestyle, modifier; kwargs...))])
+end
+
+"The linestyle patterns are inspired by the LaTeX package tikZ as seen here https://tex.stackexchange.com/questions/45275/tikz-get-values-for-predefined-dash-patterns."
+function _pattern(linestyle, modifier=:normal;
+                  dot = 1,  dot_gap  = (normal = 2, dense = 1, loose = 4),
+                  dash = 3, dash_gap = (normal = 3, dense = 2, loose = 6)
+                  )
+
+    if linestyle == :dash
+        gap = getproperty(dash_gap, modifier)
+        [dash, gap]
+    elseif linestyle == :dot
+        gap = getproperty(dot_gap, modifier)
+        [dot, gap]
+    elseif linestyle == :dashdot
+        gap = getproperty(dash_gap, modifier)
+        [dash, gap, dot, gap]
+    elseif linestyle == :dashdotdot
+        dash_gap = getproperty(dash_gap, modifier)
+        dot_gap  = getproperty(dot_gap,  modifier)
+        [dash, dash_gap, dot, dot_gap, dot, dash_gap]
     end
 end
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -677,29 +677,29 @@ convert_attribute(A::AbstractVector, ::key"linestyle") = A
 """
     A `Symbol` equal to `:dash`, `:dot`, `:dashdot`, `:dashdotdot`
 """
-convert_attribute(ls::Union{Symbol,AbstractString}, ::key"linestyle") = pattern(ls, :normal)
+convert_attribute(ls::Union{Symbol,AbstractString}, ::key"linestyle") = line_pattern(ls, :normal)
 
 function convert_attribute(ls::Tuple{<:Union{Symbol,AbstractString},<:Any}, ::key"linestyle")
-    pattern(ls[1], ls[2])
+    line_pattern(ls[1], ls[2])
 end
 
-function pattern(linestyle, gaps)
-    float.([0.0; cumsum(diff_pattern(linestyle, gaps))])
+function line_pattern(linestyle, gaps)
+    float.([0.0; cumsum(diff_line_pattern(linestyle, gaps))])
 end
 
 "The linestyle patterns are inspired by the LaTeX package tikZ as seen here https://tex.stackexchange.com/questions/45275/tikz-get-values-for-predefined-dash-patterns."
 
-function diff_pattern(ls::Symbol, gaps = :normal)
+function diff_line_pattern(ls::Symbol, gaps = :normal)
     if ls == :solid
         nothing
     elseif ls == :dash
-        diff_pattern("-", gaps)
+        diff_line_pattern("-", gaps)
     elseif ls == :dot
-        diff_pattern(".", gaps)
+        diff_line_pattern(".", gaps)
     elseif ls == :dashdot
-        diff_pattern("-.", gaps)
+        diff_line_pattern("-.", gaps)
     elseif ls == :dashdotdot
-        diff_pattern("-..", gaps)
+        diff_line_pattern("-..", gaps)
     else
         error(
             """
@@ -712,10 +712,10 @@ function diff_pattern(ls::Symbol, gaps = :normal)
     end
 end
 
-function diff_pattern(ls_str::AbstractString, gaps = :normal)
+function diff_line_pattern(ls_str::AbstractString, gaps = :normal)
     dot = 1
     dash = 3
-    check_pattern(ls_str)
+    check_line_pattern(ls_str)
     
     dot_gap, dash_gap = convert_gaps(gaps)
     
@@ -740,7 +740,7 @@ function diff_pattern(ls_str::AbstractString, gaps = :normal)
 end
 
 "Checks if the linestyle format provided as a string contains only dashes and dots"
-function check_pattern(ls_str)
+function check_line_pattern(ls_str)
     isnothing(match(r"^[\.\-]+$", ls_str)) &&
         throw(ArgumentError("If you provide a string as linestyle, it must only consist of dashes (-) and dots (.)"))
 end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -750,7 +750,9 @@ function check_pattern(ls_str)
 end
 
 function convert_gaps(gaps)
+  error_msg = "You provided the gaps modifier $gaps when specifying the linestyle. The modifier must be `∈ ([:normal, :dense, :loose])`, a real number or a collection of two real numbers."
   if gaps isa Symbol
+      gaps in [:normal, :dense, :loose] || throw(ArgumentError(error_msg))
       dot_gaps  = (normal = 2, dense = 1, loose = 4)
       dash_gaps = (normal = 3, dense = 2, loose = 6)
   
@@ -762,7 +764,7 @@ function convert_gaps(gaps)
   elseif length(gaps) == 2 && eltype(gaps) <: Real
       dot_gap, dash_gap = gaps
   else
-      throw(ArgumentError("gaps keyword must be in([:normal, :dense, :loose]) a number of a collection of two numbers."))
+      throw(ArgumentError(error_msg))
   end
   (; dot_gap, dash_gap)
 end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -684,22 +684,22 @@ function convert_attribute(ls::Tuple{<:Union{Symbol,AbstractString},<:Any}, ::ke
 end
 
 function line_pattern(linestyle, gaps)
-    float.([0.0; cumsum(diff_line_pattern(linestyle, gaps))])
+    float.([0.0; cumsum(line_diff_pattern(linestyle, gaps))])
 end
 
 "The linestyle patterns are inspired by the LaTeX package tikZ as seen here https://tex.stackexchange.com/questions/45275/tikz-get-values-for-predefined-dash-patterns."
 
-function diff_line_pattern(ls::Symbol, gaps = :normal)
+function line_diff_pattern(ls::Symbol, gaps = :normal)
     if ls == :solid
         nothing
     elseif ls == :dash
-        diff_line_pattern("-", gaps)
+        line_diff_pattern("-", gaps)
     elseif ls == :dot
-        diff_line_pattern(".", gaps)
+        line_diff_pattern(".", gaps)
     elseif ls == :dashdot
-        diff_line_pattern("-.", gaps)
+        line_diff_pattern("-.", gaps)
     elseif ls == :dashdotdot
-        diff_line_pattern("-..", gaps)
+        line_diff_pattern("-..", gaps)
     else
         error(
             """
@@ -712,7 +712,7 @@ function diff_line_pattern(ls::Symbol, gaps = :normal)
     end
 end
 
-function diff_line_pattern(ls_str::AbstractString, gaps = :normal)
+function line_diff_pattern(ls_str::AbstractString, gaps = :normal)
     dot = 1
     dash = 3
     check_line_pattern(ls_str)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -743,6 +743,8 @@ end
 function check_line_pattern(ls_str)
     isnothing(match(r"^[.-]+$", ls_str)) &&
         throw(ArgumentError("If you provide a string as linestyle, it must only consist of dashes (-) and dots (.)"))
+    
+    nothing
 end
 
 function convert_gaps(gaps)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -683,8 +683,6 @@ function convert_attribute(ls::Tuple{<:Union{Symbol,AbstractString},<:Any}, ::ke
     pattern(ls[1], ls[2])
 end
 
-using UnPack
-
 function pattern(linestyle, gaps)
     float.([0.0; cumsum(diff_pattern(linestyle, gaps))])
 end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -741,7 +741,7 @@ end
 
 "Checks if the linestyle format provided as a string contains only dashes and dots"
 function check_line_pattern(ls_str)
-    isnothing(match(r"^[\.\-]+$", ls_str)) &&
+    isnothing(match(r"^[.-]+$", ls_str)) &&
         throw(ArgumentError("If you provide a string as linestyle, it must only consist of dashes (-) and dots (.)"))
 end
 

--- a/test/unit_tests/conversions.jl
+++ b/test/unit_tests/conversions.jl
@@ -89,34 +89,34 @@ end
 import AbstractPlotting: check_pattern, diff_pattern
 
 @testset "Linetype" begin
-    @test isnothing(check_pattern("-."))
-    @test isnothing(check_pattern("--"))
-    @test_throws ArgumentError check_pattern("-.*")
+    @test isnothing(check_line_pattern("-."))
+    @test isnothing(check_line_pattern("--"))
+    @test_throws ArgumentError check_line_pattern("-.*")
 
     # for readability, the length of dash and dot
     dash, dot = 3.0, 1.0
     
-    @test diff_pattern(:dash)             ==
-          diff_pattern("-",   :normal)    == [dash, 3.0]
-    @test diff_pattern(:dot)              == 
-          diff_pattern(".",   :normal)    == [dot, 2.0]
-    @test diff_pattern(:dashdot)          ==
-          diff_pattern("-.",  :normal)    == [dash, 3.0, dot, 3.0]
-    @test diff_pattern(:dashdotdot)       == 
-          diff_pattern("-..", :normal)    == [dash, 3.0, dot, 2.0, dot, 3.0]
+    @test diff_line_pattern(:dash)             ==
+          diff_line_pattern("-",   :normal)    == [dash, 3.0]
+    @test diff_line_pattern(:dot)              == 
+          diff_line_pattern(".",   :normal)    == [dot, 2.0]
+    @test diff_line_pattern(:dashdot)          ==
+          diff_line_pattern("-.",  :normal)    == [dash, 3.0, dot, 3.0]
+    @test diff_line_pattern(:dashdotdot)       == 
+          diff_line_pattern("-..", :normal)    == [dash, 3.0, dot, 2.0, dot, 3.0]
         
-    @test diff_pattern(:dash, :loose)     == [dash, 6.0]
-    @test diff_pattern(:dot,  :loose)     == [dot, 4.0]
-    @test diff_pattern("-",   :dense)     == [dash, 2.0]
-    @test diff_pattern(".",   :dense)     == [dot, 1.0]
-    @test diff_pattern(:dash, 0.5)        == [dash, 0.5]
-    @test diff_pattern(:dot,  0.5)        == [dot, 0.5]
-    @test diff_pattern("-",   (0.4, 0.6)) == [dash, 0.6]
-    @test diff_pattern(:dot,  (0.4, 0.6)) == [dot, 0.4]
-    @test diff_pattern("-..", (0.4, 0.6)) == [dash, 0.6, dot, 0.4, dot, 0.6]
+    @test diff_line_pattern(:dash, :loose)     == [dash, 6.0]
+    @test diff_line_pattern(:dot,  :loose)     == [dot, 4.0]
+    @test diff_line_pattern("-",   :dense)     == [dash, 2.0]
+    @test diff_line_pattern(".",   :dense)     == [dot, 1.0]
+    @test diff_line_pattern(:dash, 0.5)        == [dash, 0.5]
+    @test diff_line_pattern(:dot,  0.5)        == [dot, 0.5]
+    @test diff_line_pattern("-",   (0.4, 0.6)) == [dash, 0.6]
+    @test diff_line_pattern(:dot,  (0.4, 0.6)) == [dot, 0.4]
+    @test diff_line_pattern("-..", (0.4, 0.6)) == [dash, 0.6, dot, 0.4, dot, 0.6]
 
     # gaps must be Symbol, a number, or two numbers
-    @test_throws ArgumentError diff_pattern(:dash, :NORMAL)
-    @test_throws ArgumentError diff_pattern(:dash, ()) 
-    @test_throws ArgumentError diff_pattern(:dash, (1, 2, 3))
+    @test_throws ArgumentError diff_line_pattern(:dash, :NORMAL)
+    @test_throws ArgumentError diff_line_pattern(:dash, ()) 
+    @test_throws ArgumentError diff_line_pattern(:dash, (1, 2, 3))
 end

--- a/test/unit_tests/conversions.jl
+++ b/test/unit_tests/conversions.jl
@@ -96,27 +96,27 @@ import AbstractPlotting: check_pattern, diff_pattern
     # for readability, the length of dash and dot
     dash, dot = 3.0, 1.0
     
-    @test diff_line_pattern(:dash)             ==
-          diff_line_pattern("-",   :normal)    == [dash, 3.0]
-    @test diff_line_pattern(:dot)              == 
-          diff_line_pattern(".",   :normal)    == [dot, 2.0]
-    @test diff_line_pattern(:dashdot)          ==
-          diff_line_pattern("-.",  :normal)    == [dash, 3.0, dot, 3.0]
-    @test diff_line_pattern(:dashdotdot)       == 
-          diff_line_pattern("-..", :normal)    == [dash, 3.0, dot, 2.0, dot, 3.0]
+    @test line_diff_pattern(:dash)             ==
+          line_diff_pattern("-",   :normal)    == [dash, 3.0]
+    @test line_diff_pattern(:dot)              == 
+          line_diff_pattern(".",   :normal)    == [dot, 2.0]
+    @test line_diff_pattern(:dashdot)          ==
+          line_diff_pattern("-.",  :normal)    == [dash, 3.0, dot, 3.0]
+    @test line_diff_pattern(:dashdotdot)       == 
+          line_diff_pattern("-..", :normal)    == [dash, 3.0, dot, 2.0, dot, 3.0]
         
-    @test diff_line_pattern(:dash, :loose)     == [dash, 6.0]
-    @test diff_line_pattern(:dot,  :loose)     == [dot, 4.0]
-    @test diff_line_pattern("-",   :dense)     == [dash, 2.0]
-    @test diff_line_pattern(".",   :dense)     == [dot, 1.0]
-    @test diff_line_pattern(:dash, 0.5)        == [dash, 0.5]
-    @test diff_line_pattern(:dot,  0.5)        == [dot, 0.5]
-    @test diff_line_pattern("-",   (0.4, 0.6)) == [dash, 0.6]
-    @test diff_line_pattern(:dot,  (0.4, 0.6)) == [dot, 0.4]
-    @test diff_line_pattern("-..", (0.4, 0.6)) == [dash, 0.6, dot, 0.4, dot, 0.6]
+    @test line_diff_pattern(:dash, :loose)     == [dash, 6.0]
+    @test line_diff_pattern(:dot,  :loose)     == [dot, 4.0]
+    @test line_diff_pattern("-",   :dense)     == [dash, 2.0]
+    @test line_diff_pattern(".",   :dense)     == [dot, 1.0]
+    @test line_diff_pattern(:dash, 0.5)        == [dash, 0.5]
+    @test line_diff_pattern(:dot,  0.5)        == [dot, 0.5]
+    @test line_diff_pattern("-",   (0.4, 0.6)) == [dash, 0.6]
+    @test line_diff_pattern(:dot,  (0.4, 0.6)) == [dot, 0.4]
+    @test line_diff_pattern("-..", (0.4, 0.6)) == [dash, 0.6, dot, 0.4, dot, 0.6]
 
     # gaps must be Symbol, a number, or two numbers
-    @test_throws ArgumentError diff_line_pattern(:dash, :NORMAL)
-    @test_throws ArgumentError diff_line_pattern(:dash, ()) 
-    @test_throws ArgumentError diff_line_pattern(:dash, (1, 2, 3))
+    @test_throws ArgumentError line_diff_pattern(:dash, :NORMAL)
+    @test_throws ArgumentError line_diff_pattern(:dash, ()) 
+    @test_throws ArgumentError line_diff_pattern(:dash, (1, 2, 3))
 end

--- a/test/unit_tests/conversions.jl
+++ b/test/unit_tests/conversions.jl
@@ -114,4 +114,9 @@ import AbstractPlotting: check_pattern, diff_pattern
     @test diff_pattern("-",   (0.4, 0.6)) == [dash, 0.6]
     @test diff_pattern(:dot,  (0.4, 0.6)) == [dot, 0.4]
     @test diff_pattern("-..", (0.4, 0.6)) == [dash, 0.6, dot, 0.4, dot, 0.6]
+
+    # gaps must be Symbol, a number, or two numbers
+    @test_throws ArgumentError diff_pattern(:dash, :NORMAL)
+    @test_throws ArgumentError diff_pattern(:dash, ()) 
+    @test_throws ArgumentError diff_pattern(:dash, (1, 2, 3))
 end

--- a/test/unit_tests/conversions.jl
+++ b/test/unit_tests/conversions.jl
@@ -85,3 +85,33 @@ end
     @test ilabels == [1, 2]
     @test AbstractPlotting.categoric_position.(a, Ref(ilabels)) == [1, 1, 2]
 end
+
+import AbstractPlotting: check_pattern, diff_pattern
+
+@testset "Linetype" begin
+    @test isnothing(check_pattern("-."))
+    @test isnothing(check_pattern("--"))
+    @test_throws ArgumentError check_pattern("-.*")
+
+    # for readability, the length of dash and dot
+    dash, dot = 3.0, 1.0
+    
+    @test diff_pattern(:dash)             ==
+          diff_pattern("-",   :normal)    == [dash, 3.0]
+    @test diff_pattern(:dot)              == 
+          diff_pattern(".",   :normal)    == [dot, 2.0]
+    @test diff_pattern(:dashdot)          ==
+          diff_pattern("-.",  :normal)    == [dash, 3.0, dot, 3.0]
+    @test diff_pattern(:dashdotdot)       == 
+          diff_pattern("-..", :normal)    == [dash, 3.0, dot, 2.0, dot, 3.0]
+        
+    @test diff_pattern(:dash, :loose)     == [dash, 6.0]
+    @test diff_pattern(:dot,  :loose)     == [dot, 4.0]
+    @test diff_pattern("-",   :dense)     == [dash, 2.0]
+    @test diff_pattern(".",   :dense)     == [dot, 1.0]
+    @test diff_pattern(:dash, 0.5)        == [dash, 0.5]
+    @test diff_pattern(:dot,  0.5)        == [dot, 0.5]
+    @test diff_pattern("-",   (0.4, 0.6)) == [dash, 0.6]
+    @test diff_pattern(:dot,  (0.4, 0.6)) == [dot, 0.4]
+    @test diff_pattern("-..", (0.4, 0.6)) == [dash, 0.6, dot, 0.4, dot, 0.6]
+end

--- a/test/unit_tests/conversions.jl
+++ b/test/unit_tests/conversions.jl
@@ -86,7 +86,7 @@ end
     @test AbstractPlotting.categoric_position.(a, Ref(ilabels)) == [1, 1, 2]
 end
 
-import AbstractPlotting: check_pattern, diff_pattern
+using AbstractPlotting: check_line_pattern, line_diff_pattern
 
 @testset "Linetype" begin
     @test isnothing(check_line_pattern("-."))


### PR DESCRIPTION
This improves CairoMakie. Adjusting the other two backends is still todo.

Before:

![image](https://user-images.githubusercontent.com/6280307/103906808-b432a580-5100-11eb-93ad-2f7e6cb7ce3d.png)

After:

![image](https://user-images.githubusercontent.com/6280307/103906563-6322b180-5100-11eb-9e4d-6d0dc2409dc5.png)

```julia
using CairoMakie

fig, ax, plt = lines(1:2, 2:3, linestyle=:dash)
lines!(ax, 1:2, 3:4, linestyle=:dashdot)
lines!(ax, 1:2, 4:5, linestyle=:dot)
lines!(ax, 1:2, 5:6, linestyle=:dashdotdot)

lines!(ax, 2:3, 2:3, linestyle=:dash, linewidth=5)
lines!(ax, 2:3, 3:4, linestyle=:dashdot, linewidth=5)
lines!(ax, 2:3, 4:5, linestyle=:dot, linewidth=5)
lines!(ax, 2:3, 5:6, linestyle=:dashdotdot, linewidth=5)

fig
```

fixes https://github.com/JuliaPlots/Makie.jl/issues/807