### PR TITLE
change to poly again for contourf

### DIFF
--- a/src/basic_recipes/contourf.jl
+++ b/src/basic_recipes/contourf.jl
@@ -139,11 +139,13 @@ function AbstractPlotting.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:
     # it on a first run!
     calculate_polys(xs[], ys[], zs[], c._computed_levels[], is_extended_low[], is_extended_high[])
 
-    mesh!(c,
+    poly!(c,
         polys,
         # colormap = c._computed_colormap,
         # colorrange = colorrange,
         color = colors,
+        strokewidth = 0,
+        strokecolor = :transparent,
         shading=false)
 end
 


### PR DESCRIPTION
mesh has the problem that the cairomakie backend has to use a much more memory-heavy representation for polys which blows up pdf file sizes