### PR TITLE
fix ssao rendering issue in LScene and update lighting docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -14,3 +14,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1.3"
+GLMakie = "0.1.26"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -14,4 +14,3 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1.3"
-GLMakie = "0.1.26"

--- a/docs/src/lighting.md
+++ b/docs/src/lighting.md
@@ -20,11 +20,14 @@ GLMakie also implements [_screen-space ambient occlusion_](https://learnopengl.c
 - `bias` sets the minimum difference in depth required for a pixel to
   be occluded. Increasing this will typically make the occlusion
   effect stronger.
-- `blur` sets the range of the blur applied to the occlusion texture.
+- `blur` sets the (pixel) range of the blur applied to the occlusion texture.
   The texture contains a (random) pattern, which is washed out by
   blurring. Small `blur` will be faster, sharper and more patterned.
   Large `blur` will be slower and smoother. Typically `blur = 2` is
   a good compromise.
+
+!!! note
+    The SSAO postprocessor is turned off by default to save on resources. To turn it on, set `GLMakie.enable_SSAO[] = true`, close any existing GLMakie window and reopen it.
 
 ## Matcap
 
@@ -39,8 +42,10 @@ xs = -10:0.1:10
 ys = -10:0.1:10
 zs = [10 * (cos(x) * cos(y)) * (.1 + exp(-(x^2 + y^2 + 1)/10)) for x in xs, y in ys]
 
-surface(
-    xs, ys, zs, colormap = (:white, :white),
+# Or use an LScene within a Figure
+scene = Scene()
+surface!(
+    scene, xs, ys, zs, colormap = (:white, :white),
 
     # Light comes from (0, 0, 15), i.e the sphere
     lightposition = Vec3f0(0, 0, 15),
@@ -53,10 +58,19 @@ surface(
     # Reflections are sharp
     shininess = 128f0
 )
-mesh!(Sphere(Point3f0(0, 0, 15), 1f0), color=RGBf0(1, 0.7, 0.3))
+mesh!(scene, Sphere(Point3f0(0, 0, 15), 1f0), color=RGBf0(1, 0.7, 0.3))
+scene
 ```
 
 ```@example 1
+using GLMakie
+GLMakie.enable_SSAO[] = true
+
+# Alternatively:
+# fig = Figure()
+# scene = LScene(fig[1, 1], scenekw = (SSAO = (radius = 5.0, blur = 3), show_axis=false, camera=cam3d!))
+# scene.scene[:SSAO][:bias][] = 0.025
+
 scene = Scene(show_axis = false)
 
 # SSAO attributes are per scene
@@ -66,7 +80,8 @@ scene[:SSAO][:bias][] = 0.025
 
 box = Rect3D(Point3f0(-0.5), Vec3f0(1))
 positions = [Point3f0(x, y, rand()) for x in -5:5 for y in -5:5]
-meshscatter!(positions, marker=box, markersize=1, color=:lightblue, ssao=true)
+meshscatter!(scene, positions, marker=box, markersize=1, color=:lightblue, ssao=true)
+scene
 ```
 
 ```@example 1

--- a/src/makielayout/layoutables/scene.jl
+++ b/src/makielayout/layoutables/scene.jl
@@ -25,6 +25,9 @@ function layoutable(::Type{LScene}, fig_or_scene; bbox = nothing, scenekw = Name
     layoutobservables = LayoutObservables{LScene}(attrs.width, attrs.height, attrs.tellwidth, attrs.tellheight,
         attrs.halign, attrs.valign, attrs.alignmode; suggestedbbox = bbox)
 
+    # Using clear = false (default for scenes constructed from other scenes)
+    # breaks SSAO, so we're using clear = true as a default here. This means
+    # that this LScene might draw over plot objects from other scenes...
     scene = if haskey(scenekw, :clear)
         Scene(topscene, lift(round_to_IRect2D, layoutobservables.computedbbox); scenekw...)
     else

--- a/src/makielayout/layoutables/scene.jl
+++ b/src/makielayout/layoutables/scene.jl
@@ -25,7 +25,11 @@ function layoutable(::Type{LScene}, fig_or_scene; bbox = nothing, scenekw = Name
     layoutobservables = LayoutObservables{LScene}(attrs.width, attrs.height, attrs.tellwidth, attrs.tellheight,
         attrs.halign, attrs.valign, attrs.alignmode; suggestedbbox = bbox)
 
-    scene = Scene(topscene, lift(round_to_IRect2D, layoutobservables.computedbbox); scenekw...)
+    scene = if haskey(scenekw, :clear)
+        Scene(topscene, lift(round_to_IRect2D, layoutobservables.computedbbox); scenekw...)
+    else
+        Scene(topscene, lift(round_to_IRect2D, layoutobservables.computedbbox); clear = true, scenekw...)
+    end
 
     ls = LScene(fig_or_scene, layoutobservables, attrs, Dict{Symbol, Any}(), scene)
 


### PR DESCRIPTION
Docs update for https://github.com/JuliaPlots/GLMakie.jl/pull/107.

Also fixes this issue with ssao in figures:
![Screenshot from 2021-02-03 10-33-40](https://user-images.githubusercontent.com/10947937/106746211-83239300-6622-11eb-9749-c436d3babe8e.png)

Currently SSAO distinguishes between scenes using a stencil buffer that is only written to if `scene.clear = true`. So I changed the default for `LScene`. This means an `LScene` will not render over other plots that are rendered before.

I tried a bunch of variations of 
```
fig = Figure()
Menu(fig[1, 1])
s = LScene(fig[2, 1])
scatter!(s, rand(10))
```
including 3d plots with ssao, 2d without, 2d without fxaa and different orders of operations (Menu-scene-plot, scene-menu-plot, scene-plot-menu). The Menu is always on top when opened, which is what I thought might break. 

This also means that `backgroundcolor` now works for `LScene`.