### PR TITLE
fix issue with selecting a camera and drawing Axis3D to LScene

### DIFF
--- a/src/makielayout/layoutables/scene.jl
+++ b/src/makielayout/layoutables/scene.jl
@@ -25,14 +25,13 @@ function layoutable(::Type{LScene}, fig_or_scene; bbox = nothing, scenekw = Name
     layoutobservables = LayoutObservables{LScene}(attrs.width, attrs.height, attrs.tellwidth, attrs.tellheight,
         attrs.halign, attrs.valign, attrs.alignmode; suggestedbbox = bbox)
 
-    # Using clear = false (default for scenes constructed from other scenes)
+    # Using `clear = false` (default for scenes constructed from other scenes)
     # breaks SSAO, so we're using clear = true as a default here. This means
-    # that this LScene might draw over plot objects from other scenes...
-    scene = if haskey(scenekw, :clear)
-        Scene(topscene, lift(round_to_IRect2D, layoutobservables.computedbbox); scenekw...)
-    else
-        Scene(topscene, lift(round_to_IRect2D, layoutobservables.computedbbox); clear = true, scenekw...)
-    end
+    # that this LScene might draw over plot objects from other scenes.
+    # We also set `raw = false` because otherwise the scene will not automatically
+    # pick a camera and draw axis.
+    scenekw = merge((raw = false, clear = true), scenekw)
+    scene = Scene(topscene, lift(round_to_IRect2D, layoutobservables.computedbbox); scenekw...)
 
     ls = LScene(fig_or_scene, layoutobservables, attrs, Dict{Symbol, Any}(), scene)
 


### PR DESCRIPTION
Other layoutable may set the root set to `raw = true`, which propagates to LScene and causes it to not choose a camera and not draw Axis3D (when applicable). This should fix it.