### PR TITLE
GroupedBarPlot recipe

### DIFF
--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -62,3 +62,71 @@ function AbstractPlotting.plot!(p::BarPlot)
         strokewidth = p.strokewidth, strokecolor = p.strokecolor, visible = p.visible
     )
 end
+
+"""
+    groupedbarplot(x, groups; kwargs...)
+
+Plots a grouped barplot; `groups` defines heights by group, i.e. each group corresponds to a normal barplot's `y`.  `x`, `groups` and all `group ∈ groups` should be 1 dimensional.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(GroupedBarPlot, x, groups) do scene
+    default_theme(scene, BarPlot)
+end
+
+AbstractPlotting.conversion_trait(::Type{GroupedBarPlot}) = NoConversion()
+
+function AbstractPlotting.plot!(p::GroupedBarPlot)
+    widths = lift(p.width, p[1], p[2]) do width, x, groups
+        n_x, n_groups = length(x), length(groups)
+        extra_space = sum(diff(x)) / n_x # half of this on either end
+        group_span = (x[end] - x[begin] + extra_space) / n_x
+        if width === AbstractPlotting.automatic
+            bars_span = group_span * 0.8
+            bar_span = bars_span / n_groups
+            [bar_span for group in groups]
+        elseif width isa Number
+            @assert width > 0
+            @assert width * n_groups <= group_span
+            [width for group in groups]
+        elseif width isa AbstractVector
+            @assert length(width) == length(groups)
+            @assert sum(width) <= group_span
+            width
+        else
+            error("Unsupported type for GroupedBarPlot attribute `width`")
+        end
+    end
+
+    group_xs = lift(p[1], p[2], widths) do x, groups, widths
+        bars_span = sum(widths)
+        # first bar starts at: x - (bars_span/2) + (widths[begin]/2)
+        group_xs = map(enumerate(groups)) do (i_group, group)
+            # first bar start + preceding bar widths + half current bar
+            midpoint_offset = -bars_span / 2 + sum(widths[1:i_group-1]) + widths[i_group]/2
+            x .+ midpoint_offset
+        end
+        return group_xs
+    end
+
+    colors = lift(p.color, p[2], p.parent.backgroundcolor) do color, groups, bgcolor
+        n_groups = length(groups)
+        if color isa AbstractArray && length(color) == n_groups
+            color
+        else
+            distinguishable_colors(n_groups, parse(Colorant, bgcolor), dropseed=true)
+        end
+    end
+
+    p = lift(group_xs, p[2], colors, widths) do group_xs, group_ys, colors, widths
+        for (group_x, group_y, color, width) ∈ zip(group_xs, group_ys, colors, widths)
+            barplot!(p, group_x, group_y; p.attributes..., color=color, width=width)
+        end
+        p
+    end
+
+    p
+end
+
+AbstractPlotting.Legend(fig_or_scene, grouped_bar::GroupedBarPlot, args...; kwargs...) = Legend(fig_or_scene, grouped_bar.plots, args...; kwargs...)


### PR DESCRIPTION
A GroupedBarPlot `gbp` takes `x` and `groups` and plots `[barplot!(gbp, x .+ offset(group)), group; gbp.attributes..., color=color(group), width=width(group))  for group in groups]`, calculating the offset, the width, and the color such that the resulting plot has at each value of `x` a series of adjacent bars, one for each group in `groups`, colored by group identity.

Since at its core it just calls `barplot!`, all the `BarPlot` attributes should work as usual, except color and width, which are both overridden to specify a color or width for each group (though a scalar width does fix all the bar widths). Also I overrode `Legend` to create an appropriate legend given a list of group labels, but I haven't overridden `label` to take labels at time of plot creation.

TODOs:
- [ ] Use colormap to generate bar colors
- [ ] Split `label` specification across groups
- [ ] Split other attributes across groups?
- [ ] Add attribute for spacing between bars
- [ ] Example in docs (addresses single checkbox in https://github.com/JuliaPlots/Makie.jl/issues/115)
- [ ] Figure out how actually to override `Legend`, since it doesn't seem to be defined at this point
- [ ] Compare with #580