### PR TITLE
Add more attributes to `scatterlines`

### DIFF
--- a/src/basic_recipes/scatterlines.jl
+++ b/src/basic_recipes/scatterlines.jl
@@ -14,11 +14,13 @@ $(ATTRIBUTES)
         colormap = l_theme.colormap,
         colorrange = get(l_theme.attributes, :colorrange, automatic),
         linestyle = l_theme.linestyle,
+        linewidth = l_theme.linewidth,
         markercolor = s_theme.color,
         markercolormap = s_theme.colormap,
         markercolorrange = get(s_theme.attributes, :colorrange, automatic),
         markersize = s_theme.markersize,
         strokecolor = s_theme.strokecolor,
+        strokewidth = s_theme.strokewidth,
         marker = s_theme.marker,
     )
 end
@@ -28,12 +30,14 @@ function plot!(p::Combined{scatterlines, <:NTuple{N, Any}}) where N
     lines!(p, p[1:N]...;
         color = p.color,
         linestyle = p.linestyle,
+        linewidth = p.linewidth,
         colormap = p.colormap,
         colorrange = p.colorrange,
     )
     scatter!(p, p[1:N]...;
         color = p.markercolor,
         strokecolor = p.strokecolor,
+        strokewidth = p.strokewidth,
         marker = p.marker,
         markersize = p.markersize,
         colormap = p.markercolormap,


### PR DESCRIPTION
This PR adds the attributes `linewidth` and `strokewidth` to `scatterlines` (see https://github.com/JuliaPlots/Makie.jl/issues/854#issuecomment-786566961).