### PR TITLE
Handle length 1 barplot data.

### DIFF
--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -50,7 +50,7 @@ function AbstractPlotting.plot!(p::BarPlot)
         # compute half-width of bars
         if width === automatic
             # times 0.8 for default gap
-            width = mean(diff(first.(xy))) * 0.8 # TODO ignore nan?
+            width = length(xy) > 1 ? mean(diff(first.(xy))) * 0.8 : 0.8
         end
 
         rects = bar_rectangle.(xy, width, fillto)

--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -50,7 +50,8 @@ function AbstractPlotting.plot!(p::BarPlot)
         # compute half-width of bars
         if width === automatic
             # times 0.8 for default gap
-            width = length(xy) > 1 ? mean(diff(first.(xy))) * 0.8 : 0.8
+            width = mean(diff(first.(xy))) * 0.8
+            width = ifelse(isfinite(width), width, 0.8)
         end
 
         rects = bar_rectangle.(xy, width, fillto)


### PR DESCRIPTION
Stops the propagation of NaN through from the automatic width calc. Not 100% sure this is a suitable fix, but does seem to work from what I've tried. Where/who should this get tested?