### PR TITLE
Clean up categorical

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -118,11 +118,9 @@ categorical_range(xs) = categorical_range(categorical_trait(xs), xs)
 categorical_range(::Categorical, xs) = 1:length(categorical_labels(xs))
 categorical_range(::Continuous,  _)  = automatic # we let them be automatic
 
-function categorical_position(x, labels)
-    findfirst(l -> l == x, labels)
-end
-
-categorical_position(x, labels::Automatic) = x
+categorical_position(x, xs) = categorical_position(categorical_trait(xs), x, xs)
+categorical_position(::Categorical, x, xs) = findfirst(l -> l == x, categorical_labels(xs))
+categorical_position(::Continuous,  x, _)  = x
 
 convert_arguments(P::PointBased, x::AbstractVector, y::AbstractVector) = convert_arguments(P, (x, y))
 convert_arguments(P::PointBased, x::AbstractVector, y::AbstractVector, z::AbstractVector) = convert_arguments(P, (x, y, z))
@@ -135,7 +133,7 @@ function convert_arguments(::PointBased, positions::NTuple{N, AbstractVector}) w
     labels = categorical_labels.(positions)
     xyrange = categorical_range.(positions)
     points = map(zip(positions...)) do p
-        Point{N, Float32}(categorical_position.(p, labels))
+        Point{N, Float32}(categorical_position.(p, positions))
     end
     PlotSpec(points, tickranges = xyrange, ticklabels = labels)
 end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -105,24 +105,24 @@ end
 
 # Trait for categorical values
 struct Categorical end
-struct Continous end
+struct Continuous end
 
 categorical_trait(::Type) = Categorical()
-categorical_trait(::Type{<: Number}) = Continous()
+categorical_trait(::Type{<: Number}) = Continuous()
 
-categoric_labels(x::AbstractVector{T}) where T = categoric_labels(categorical_trait(T), x)
+categorical_labels(x::AbstractVector{T}) where T = categorical_labels(categorical_trait(T), x)
 
-categoric_labels(::Categorical, x) = unique(x)
-categoric_labels(::Continous, x) = automatic # we let them be automatic
+categorical_labels(::Categorical, x) = unique(x)
+categorical_labels(::Continuous, x) = automatic # we let them be automatic
 
-categoric_range(range::Automatic) = range
-categoric_range(range) = 1:length(range)
+categorical_range(labels::Automatic) = labels
+categorical_range(labels) = 1:length(labels)
 
-function categoric_position(x, labels)
+function categorical_position(x, labels)
     findfirst(l -> l == x, labels)
 end
 
-categoric_position(x, labels::Automatic) = x
+categorical_position(x, labels::Automatic) = x
 
 convert_arguments(P::PointBased, x::AbstractVector, y::AbstractVector) = convert_arguments(P, (x, y))
 convert_arguments(P::PointBased, x::AbstractVector, y::AbstractVector, z::AbstractVector) = convert_arguments(P, (x, y, z))
@@ -132,10 +132,10 @@ function convert_arguments(::PointBased, positions::NTuple{N, AbstractVector}) w
     if any(n-> length(x) != length(n), positions)
         error("All vectors need to have the same length. Found: $(length.(positions))")
     end
-    labels = categoric_labels.(positions)
-    xyrange = categoric_range.(labels)
+    labels = categorical_labels.(positions)
+    xyrange = categorical_range.(labels)
     points = map(zip(positions...)) do p
-        Point{N, Float32}(categoric_position.(p, labels))
+        Point{N, Float32}(categorical_position.(p, labels))
     end
     PlotSpec(points, tickranges = xyrange, ticklabels = labels)
 end
@@ -146,8 +146,8 @@ function convert_arguments(
     )
     n, m = size(z)
     positions = (x, y)
-    labels = categoric_labels.(positions)
-    xyrange = categoric_range.(labels)
+    labels = categorical_labels.(positions)
+    xyrange = categorical_range.(labels)
     args = convert_arguments(SL, 0..n, 0..m, z)
     xyranges = (
         to_linspace(0.5..(n-0.5), n),

--- a/src/stats/conversions.jl
+++ b/src/stats/conversions.jl
@@ -16,7 +16,7 @@ function convert_arguments(::SampleBased, positions::NTuple{N,AbstractVector}) w
     labels = categorical_labels.(positions)
     xyrange = categorical_range.(positions)
     newpos = map(positions) do pos
-        el32convert(categorical_position.(pos, Ref(pos)))
+        el32convert(categorical_positions(pos))
     end
     PlotSpec(newpos...; tickranges = xyrange, ticklabels = labels)
 end

--- a/src/stats/conversions.jl
+++ b/src/stats/conversions.jl
@@ -15,8 +15,8 @@ function convert_arguments(::SampleBased, positions::NTuple{N,AbstractVector}) w
     end
     labels = categorical_labels.(positions)
     xyrange = categorical_range.(positions)
-    newpos = map(positions, labels) do pos,lab
-        el32convert(categorical_position.(pos, Ref(lab)))
+    newpos = map(positions) do pos
+        el32convert(categorical_position.(pos, Ref(pos)))
     end
     PlotSpec(newpos...; tickranges = xyrange, ticklabels = labels)
 end

--- a/src/stats/conversions.jl
+++ b/src/stats/conversions.jl
@@ -14,7 +14,7 @@ function convert_arguments(::SampleBased, positions::NTuple{N,AbstractVector}) w
         error("all vector need to be same length. Found: $(length.(positions))")
     end
     labels = categorical_labels.(positions)
-    xyrange = categorical_range.(labels)
+    xyrange = categorical_range.(positions)
     newpos = map(positions, labels) do pos,lab
         el32convert(categorical_position.(pos, Ref(lab)))
     end

--- a/src/stats/conversions.jl
+++ b/src/stats/conversions.jl
@@ -13,10 +13,10 @@ function convert_arguments(::SampleBased, positions::NTuple{N,AbstractVector}) w
     if any(n-> length(x) != length(n), positions)
         error("all vector need to be same length. Found: $(length.(positions))")
     end
-    labels = categoric_labels.(positions)
-    xyrange = categoric_range.(labels)
+    labels = categorical_labels.(positions)
+    xyrange = categorical_range.(labels)
     newpos = map(positions, labels) do pos,lab
-        el32convert(categoric_position.(pos, Ref(lab)))
+        el32convert(categorical_position.(pos, Ref(lab)))
     end
     PlotSpec(newpos...; tickranges = xyrange, ticklabels = labels)
 end

--- a/test/unit_tests/conversions.jl
+++ b/test/unit_tests/conversions.jl
@@ -116,9 +116,9 @@ end
 @testset "Categorical values" begin
     # AbstractPlotting.jl#345
     a = Any[Int64(1), Int32(1), Int128(2)] # vector of categorical values of different types
-    ilabels = AbstractPlotting.categoric_labels(a)
+    ilabels = AbstractPlotting.categorical_labels(a)
     @test ilabels == [1, 2]
-    @test AbstractPlotting.categoric_position.(a, Ref(ilabels)) == [1, 1, 2]
+    @test AbstractPlotting.categorical_position.(a, Ref(ilabels)) == [1, 1, 2]
 end
 
 using AbstractPlotting: check_line_pattern, line_diff_pattern

--- a/test/unit_tests/conversions.jl
+++ b/test/unit_tests/conversions.jl
@@ -118,7 +118,7 @@ end
     a = Any[Int64(1), Int32(1), Int128(2)] # vector of categorical values of different types
     ilabels = AbstractPlotting.categorical_labels(a)
     @test ilabels == [1, 2]
-    @test AbstractPlotting.categorical_position.(a, Ref(ilabels)) == [1, 1, 2]
+    @test AbstractPlotting.categorical_position.(a, Ref(a)) == [1, 1, 2]
 end
 
 using AbstractPlotting: check_line_pattern, line_diff_pattern


### PR DESCRIPTION
This PR cleans up code and does some refactoring to make the follow-up PR #667  easier to review.

- [x] rename Continous => `Continuous`
- [x] rename categoric_fun => `categorical_fun`
- [x] use consistent arguments across `categorical_fun`
- [x] add `categorical_positions` (note the plural) to avoid recomputing `categorical_labels` for old-style `Categorical`

Please let me know how I can help making the review easier for you.

Does this need extra tests?

This
```julia
scatter(["a", "b", "c"], ["d", "e", "f"], [5, 6, 7])
```
works as expected.

<img width="506" alt="image" src="https://user-images.githubusercontent.com/6280307/112609009-4f433d80-8e1b-11eb-912a-ed074b5abefa.png">
