### PR TITLE
add screenspace_boundingbox for text

### DIFF
--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -9,7 +9,9 @@ module Formatters
         try
             Showoff.showoff(ticks, :plain)
         catch e
+            bt = Base.catch_backtrace()
             Base.showerror(stderr, e)
+            Base.show_backtrace(stderr, bt)
             println("with ticks: ", ticks)
             String["-Inf", "Inf"]
         end

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -43,6 +43,18 @@ struct Glyphlayout
     hadvances::Vector{Float32}
 end
 
+function boundingbox(gl::Glyphlayout)
+    bbox = FRect3D(
+        gl.origins[1] .+ Vec3f0(origin(gl.bboxes[1])..., 0), 
+        Vec3f0(widths(gl.bboxes[1])..., 0)
+    )
+    for (o, bb) in zip(gl.origins[2:end], gl.bboxes[2:end])
+        bbox2 = FRect3D(o .+ Vec3f0(origin(bb)..., 0), Vec3f0(widths(bb)..., 0))
+        bbox = union(bbox, bbox2)
+    end
+    bbox
+end
+
 """
     layout_text(
         string::AbstractString, textsize::Union{AbstractVector, Number},


### PR DESCRIPTION
## Check 1:
```julia
using AbstractPlotting: origin
fig, ax, p = text("He\nllo")
bbox = AbstractPlotting.screenspace_boundingbox(p)
adjusted = map(bbox, pixelarea(fig.scene), pixelarea(ax.scene)) do bb, trg, src
    bb + to_ndim(Vec3f0, origin(src), 0) - to_ndim(Vec3f0, origin(trg), 0)
end
wireframe!(fig.scene, adjusted, color=:red)
fig
```

![Screenshot from 2021-03-29 17-31-09](https://user-images.githubusercontent.com/10947937/112861314-fb538580-90b4-11eb-8222-90bd10855162.png)

I think the gap here is a result of how "\n" is handled?

## Check 2.0:
```julia
fig, ax, p = text(["Hello", "hi"], position=[Point3f0(0), Point3f0(1,1,2)])
bboxes = AbstractPlotting.screenspace_boundingbox(p)
adjusted = map(bboxes) do bbox
    map(bbox, pixelarea(fig.scene), pixelarea(ax.scene)) do bb, trg, src
        bb + to_ndim(Vec3f0, origin(src), 0) - to_ndim(Vec3f0, origin(trg), 0)
    end
end
wireframe!(fig.scene, adjusted[1], color=:red)
wireframe!(fig.scene, adjusted[2], color=:blue)
fig
```
This fails with 
```
InexactError: check_top_bit(UInt64, -9223372036854775481)with ticks: [0.0]
InexactError: check_top_bit(UInt64, -9223372036854775481)with ticks: [0.0]
InexactError: check_top_bit(UInt64, -9223372036854775481)with ticks: [0.0]
```

## Check 2.1:
```julia
using AbstractPlotting: origin, scalematrix, translationmatrix
fig, ax, p = text(["Hello", "hi"], position=[Point3f0(0), Point3f0(1,1,2)])
bboxes = AbstractPlotting.screenspace_boundingbox(p)
wireframe!(ax.scene, 
    bboxes[1], 
    color = :red, 
    model = map(
            camera(ax.scene).projectionview, 
            ax.scene.px_area
        ) do pv, rect
        inv(pv) * 
        scalematrix(Vec3f0((2.0 ./ widths(rect))..., 1)) *
        translationmatrix(Vec3f0(-0.5widths(rect)..., 0))
    end
)
wireframe!(ax.scene, 
    bboxes[2], 
    color = :red, 
    model = map(
            camera(ax.scene).projectionview, 
            ax.scene.px_area
        ) do pv, rect
        inv(pv) * 
        scalematrix(Vec3f0((2.0 ./ widths(rect))..., 1)) *
        translationmatrix(Vec3f0(-0.5widths(rect)..., 0))
    end
)
fig
```

Works, but massively rescales the axes because our bounding boxes ignore `model` matrices. 
![Screenshot from 2021-03-29 17-33-48](https://user-images.githubusercontent.com/10947937/112861439-14f4cd00-90b5-11eb-877c-a9c5c4c6295d.png)