### PR TITLE
jk/colorbar fixes

### DIFF
--- a/docs/src/makielayout/colorbar.md
+++ b/docs/src/makielayout/colorbar.md
@@ -38,7 +38,7 @@ Colorbar(fig[4, 1], height = 25, limits = (-1, 1), colormap = :heat,
 fig
 ```
 
-You can also automatically choose colormap and limits for certain plot objects by passing them as the second argument.
+If you pass a `plotobject`, a `heatmap` or `contourf`, the Colorbar is set up automatically such that it tracks these objects' relevant attributes like `colormap`, `colorrange`, `highclip` and `lowclip`. If you want to adjust these attributes afterwards, change them in the plot object, otherwise the Colorbar and the plot object will go out of sync.
 
 ```@example
 using CairoMakie

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -48,6 +48,7 @@ $(ATTRIBUTES)
     Attributes(;
         default_theme(scene)...,
         colormap = [:black, :white],
+        colorrange = automatic,
         interpolate = true,
         fxaa = false,
         lowclip = nothing,
@@ -70,6 +71,7 @@ $(ATTRIBUTES)
     Attributes(;
         default_theme(scene)...,
         colormap = :viridis,
+        colorrange = automatic,
         linewidth = 0.0,
         interpolate = false,
         levels = 1,
@@ -120,6 +122,7 @@ $(ATTRIBUTES)
         default_theme(scene)...,
         color = nothing,
         colormap = :viridis,
+        colorrange = automatic,
         shading = true,
         fxaa = true,
         lowclip = nothing,
@@ -147,6 +150,7 @@ $(ATTRIBUTES)
         linewidth = 1.0,
         color = :black,
         colormap = :viridis,
+        colorrange = automatic,
         linestyle = nothing,
         fxaa = false
     )
@@ -183,6 +187,7 @@ $(ATTRIBUTES)
         default_theme(scene)...,
         color = :black,
         colormap = :viridis,
+        colorrange = automatic,
         interpolate = false,
         shading = true,
         fxaa = true,
@@ -204,6 +209,7 @@ $(ATTRIBUTES)
         default_theme(scene)...,
         color = :gray65,
         colormap = :viridis,
+        colorrange = automatic,
         marker = Circle,
         markersize = 10,
 

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -373,6 +373,13 @@ function default_attributes(::Type{Colorbar}, scene)
 end
 
 @doc """
+    Colorbar(parent; kwargs...)
+    Colorbar(parent, plotobject; kwargs...)
+    Colorbar(parent, heatmap::Heatmap; kwargs...)
+    Colorbar(parent, contourf::Contourf; kwargs...)
+
+Add a Colorbar to `parent`. If you pass a `plotobject`, a `heatmap` or `contourf`, the Colorbar is set up automatically such that it tracks these objects' relevant attributes like `colormap`, `colorrange`, `highclip` and `lowclip`. If you want to adjust these attributes afterwards, change them in the plot object, otherwise the Colorbar and the plot object will go out of sync.
+
 Colorbar has the following attributes:
 
 $(let

--- a/src/makielayout/layoutables/colorbar.jl
+++ b/src/makielayout/layoutables/colorbar.jl
@@ -1,5 +1,11 @@
 function layoutable(::Type{<:Colorbar}, fig_or_scene, plot::AbstractPlot; kwargs...)
 
+    for key in (:colormap, :limits)
+        if key in keys(kwargs)
+            error("You should not pass the `$key` attribute to the colorbar when constructing it using an existing plot object. This attribute is copied from the plot object, and setting it from the colorbar will make the plot object and the colorbar go out of sync.")
+        end
+    end
+
     layoutable(Colorbar, fig_or_scene;
         colormap = plot.colormap,
         limits = plot.colorrange,
@@ -9,6 +15,12 @@ function layoutable(::Type{<:Colorbar}, fig_or_scene, plot::AbstractPlot; kwargs
 end
 
 function layoutable(::Type{<:Colorbar}, fig_or_scene, heatmap::Union{Heatmap, Image}; kwargs...)
+
+    for key in (:colormap, :limits, :highclip, :lowclip)
+        if key in keys(kwargs)
+            error("You should not pass the `$key` attribute to the colorbar when constructing it using an existing plot object. This attribute is copied from the plot object, and setting it from the colorbar will make the plot object and the colorbar go out of sync.")
+        end
+    end
 
     layoutable(Colorbar, fig_or_scene;
         colormap = heatmap.colormap,
@@ -20,6 +32,12 @@ function layoutable(::Type{<:Colorbar}, fig_or_scene, heatmap::Union{Heatmap, Im
 end
 
 function layoutable(::Type{<:Colorbar}, fig_or_scene, plot::AbstractPlotting.Contourf; kwargs...)
+
+    for key in (:colormap, :limits, :highclip, :lowclip)
+        if key in keys(kwargs)
+            error("You should not pass the `$key` attribute to the colorbar when constructing it using an existing plot object. This attribute is copied from the plot object, and setting it from the colorbar will make the plot object and the colorbar go out of sync.")
+        end
+    end
 
     steps = plot._computed_levels
 

--- a/src/makielayout/layoutables/colorbar.jl
+++ b/src/makielayout/layoutables/colorbar.jl
@@ -31,7 +31,7 @@ function layoutable(::Type{<:Colorbar}, fig_or_scene, heatmap::Union{Heatmap, Im
     )
 end
 
-function layoutable(::Type{<:Colorbar}, fig_or_scene, plot::AbstractPlotting.Contourf; kwargs...)
+function layoutable(::Type{<:Colorbar}, fig_or_scene, contourf::AbstractPlotting.Contourf; kwargs...)
 
     for key in (:colormap, :limits, :highclip, :lowclip)
         if key in keys(kwargs)
@@ -39,17 +39,17 @@ function layoutable(::Type{<:Colorbar}, fig_or_scene, plot::AbstractPlotting.Con
         end
     end
 
-    steps = plot._computed_levels
+    steps = contourf._computed_levels
 
     limits = lift(steps) do steps
         steps[1], steps[end]
     end
 
     layoutable(Colorbar, fig_or_scene;
-        colormap = plot._computed_colormap,
+        colormap = contourf._computed_colormap,
         limits = limits,
-        lowclip = plot._computed_extendlow,
-        highclip = plot._computed_extendhigh,
+        lowclip = contourf._computed_extendlow,
+        highclip = contourf._computed_extendhigh,
         kwargs...
     )
 

--- a/test/unit_tests/makielayout.jl
+++ b/test/unit_tests/makielayout.jl
@@ -87,3 +87,19 @@ end
     @test ax.targetlimits[] == BBox(-5, 11, 5, 7)
     @test ax.finallimits[] == BBox(-5, 11, 5, 7)
 end
+
+@testset "Colorbar plot object kwarg clash" begin
+    for attr in (:colormap, :limits)
+        f, ax, p = scatter(1:10, 1:10, color = 1:10, colorrange = (1, 10))
+        Colorbar(f[2, 1], p)
+        @test_throws ErrorException Colorbar(f[2, 1], p; Dict(attr => nothing)...)
+    end
+
+    for attr in (:colormap, :limits, :highclip, :lowclip)
+        for F in (heatmap, contourf)
+            f, ax, p = F(1:10, 1:10, randn(10, 10))
+            Colorbar(f[1, 2], p)
+            @test_throws ErrorException Colorbar(f[1, 3], p; Dict(attr => nothing)...)
+        end
+    end
+end


### PR DESCRIPTION
- disallow setting already set colorbar attributes, add tests
- add automatic colorrange to basic plots so docs are less confusing
