### PR TITLE
small tweaks to barplot dodge formulas

### DIFF
--- a/docs/src/plotting_functions/barplot.md
+++ b/docs/src/plotting_functions/barplot.md
@@ -23,6 +23,17 @@ barplot!(xs, ys .- 1, fillto = -1, color = xs, strokecolor = :black, strokewidth
 f
 ```
 
+```@example
+using CairoMakie
+CairoMakie.activate!() # hide
+AbstractPlotting.inline!(true) # hide
+
+xs = 1:0.2:10
+ys = 0.5 .* sin.(xs)
+
+barplot(xs, ys, width = step(xs), color = :gray85, strokecolor = :black, strokewidth = 1)
+```
+
 ```@example bar
 using CairoMakie
 CairoMakie.activate!() # hide

--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -13,6 +13,7 @@ $(ATTRIBUTES)
         colormap = theme(scene, :colormap),
         colorrange = automatic,
         dodge = automatic,
+        n_dodge = automatic,
         x_gap = 0.2,
         dodge_gap = 0.03,
         marker = Rect,
@@ -49,11 +50,11 @@ function AbstractPlotting.plot!(p::BarPlot)
         end
     end
 
-    bars = lift(p[1], p.fillto, p.width, p.dodge, p.x_gap, p.dodge_gap, p.stack, in_y_direction) do xy, fillto, width, dodge, x_gap, dodge_gap, stack, in_y_direction
+    bars = lift(p[1], p.fillto, p.width, p.dodge, p.n_dodge, p.x_gap, p.dodge_gap, p.stack, in_y_direction) do xy, fillto, width, dodge, n_dodge, x_gap, dodge_gap, stack, in_y_direction
         
         x = first.(xy)
         y = last.(xy)
-        
+
         # compute width of bars
         if width === automatic
             x_unique = unique(filter(isfinite, x))
@@ -74,7 +75,7 @@ function AbstractPlotting.plot!(p::BarPlot)
             ArgumentError("The keyword argument `dodge` currently supports only `AbstractVector{<: Integer}`") |> throw
         end
 
-        n_dodge = maximum(i_dodge)
+        n_dodge === automatic && (n_dodge = maximum(i_dodge))
 
         dodge_width = scale_width(dodge_gap, n_dodge)
 

--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -13,7 +13,7 @@ $(ATTRIBUTES)
         colormap = theme(scene, :colormap),
         colorrange = automatic,
         dodge = automatic,
-        x_gap = 0.1,
+        x_gap = 0.2,
         dodge_gap = 0.03,
         marker = Rect,
         stack = automatic,
@@ -54,15 +54,12 @@ function AbstractPlotting.plot!(p::BarPlot)
         x = first.(xy)
         y = last.(xy)
         
-        # compute half-width of bars
+        # compute width of bars
         if width === automatic
             x_unique = unique(filter(isfinite, x))
-            
-            if length(x_unique) == 1
-                width = 1 - 2x_gap
-            else
-                width = (1 - 2x_gap) * mean(diff(sort(x_unique)))
-            end
+            x_diffs = diff(sort(x_unique))
+            minimum_distance = isempty(x_diffs) ? 1.0 : minimum(x_diffs)
+            width = (1 - x_gap) * minimum_distance
         end
 
         # --------------------------------


### PR DESCRIPTION
This addresses the concern in https://github.com/JuliaPlots/AbstractPlotting.jl/pull/580/files#r619388750

Basically now `x_gap` is used only if the user does not pass an explicit `width`, otherwise the `width` is respected (I've added an example for this). This also allows to simplify the formulas for the "dodge" computation.