### PR TITLE
Get rid of the sitename since the logo is the sitename

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -339,6 +339,7 @@ makedocs(
             "assets/favicon.ico",
             "assets/syntaxtheme.css"
         ],
+        sidebar_sitename=false,
     ),
     sitename = "Makie Plotting Ecosystem",
     pages = Any[


### PR DESCRIPTION
This removes 
![image](https://user-images.githubusercontent.com/4319522/116146704-c84ce380-a6ac-11eb-9588-f6648df6c3eb.png)

Since the logo serves the same purpose.