### PR TITLE
fix zoom for scroll values larger than +-1

### DIFF
--- a/src/camera/camera2d.jl
+++ b/src/camera/camera2d.jl
@@ -138,7 +138,7 @@ function add_zoom!(scene::SceneLike, cam::Camera2D)
         zoom = Float32(x[2])
         if zoom != 0 && ispressed(scene, zoombutton) && is_mouseinside(scene)
             pa = pixelarea(scene)[]
-            z = 1f0 + (zoom * zoomspeed)
+            z = (1f0 - zoomspeed)^zoom
             mp = Vec2f0(e.mouseposition[]) - minimum(pa)
             mp = (mp .* wscale(pa, area)) + minimum(area)
             p1, p2 = minimum(area), maximum(area)

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -239,11 +239,11 @@ function zoom!(scene, point, zoom_step, shift_lookat::Bool)
         if projectiontype == Perspective
             ray_dir *= norm(dir)
         end
-        cam.eyeposition[] = eyeposition + (ray_dir - dir) * 0.1f0 * zoom_step
-        cam.lookat[] = lookat + zoom_step * 0.1f0 * ray_dir
+        cam.eyeposition[] = eyeposition + (ray_dir - dir) * (1f0 - 0.9f0 ^ zoom_step)
+        cam.lookat[] = lookat + (1f0 - 0.9f0 ^ zoom_step) * ray_dir
     else
         # Rotations need more extreme eyeposition shifts
-        cam.eyeposition[] = eyeposition + (ray_dir - dir * 0.1f0) * zoom_step
+        cam.eyeposition[] = eyeposition + sign(zoom_step) * (ray_dir - dir * (1f0 - 0.9f0^abs(zoom_step)))
     end
 
     update_cam!(scene, cam)

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -243,7 +243,12 @@ function zoom!(scene, point, zoom_step, shift_lookat::Bool)
         cam.lookat[] = lookat + (1f0 - 0.9f0 ^ zoom_step) * ray_dir
     else
         # Rotations need more extreme eyeposition shifts
-        cam.eyeposition[] = eyeposition + sign(zoom_step) * (ray_dir - dir * (1f0 - 0.9f0^abs(zoom_step)))
+        step = zoom_step
+        while abs(step) > 1f0
+            cam.eyeposition[] = cam.eyeposition[] + sign(zoom_step) * (ray_dir - dir * 0.1f0)
+            dir = cam.eyeposition[] - lookat
+            step -= sign(step)
+        end
     end
 
     update_cam!(scene, cam)

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -252,11 +252,7 @@ function process_interaction(s::ScrollZoom, event::ScrollEvent, ax::Axis)
     if zoom != 0
         pa = pixelarea(scene)[]
 
-        # don't let z go negative
-        z = max(0.1f0, 1f0 - (abs(zoom) * s.speed))
-        if zoom < 0
-            z = 1/z   # sets the old to be a fraction of the new. This ensures zoom in & then out returns to original position.
-        end
+        z = (1f0 - s.speed)^zoom
 
         mp_axscene = Vec4f0((e.mouseposition[] .- pa.origin)..., 0, 1)
 


### PR DESCRIPTION
The zoom formula we currently have assume scroll to be -1, 0 or +1. If this is not the case the zoom factor can becomes negative which messes things up (e.g. flipping axes). This pr should fix that by using scroll steps as an exponent. 

This changes the zoom behavior slightly. For `cam2d!` the zoom in and the zoom out were different factors, meaning you didn't get back to the same point. Now you should. MakieLayout / Axis should act the same I think. `cam3d!` now (did it used to?) also returns to the same position. `cam3d_cad!` should act the same as before with scrolls of -1, 0, 1 without going crazy with larger scroll values.