### PR TITLE
Update doc consistency and outdated syntax in some examples

### DIFF
--- a/docs/src/figure.md
+++ b/docs/src/figure.md
@@ -1,13 +1,13 @@
-# Figure
+# `Figure`
 
 The `Figure` object contains a top-level `Scene` and a `GridLayout`, as well as a list of layoutables that have been placed into it, like `Axis`, `Colorbar`, `Slider`, `Legend`, etc.
 
 !!! note
-    Wherever you see the old `scene, layout = layoutscene()` workflow from MakieLayout, you can imagine that 
+    Wherever you see the old `scene, layout = layoutscene()` workflow from MakieLayout, you can imagine that
     the `Figure` takes over the role of both `scene` and `layout`, plus additional conveniences like keeping
     track of layoutables.
 
-## Creating A Figure
+## Creating a `Figure`
 
 You can create a figure explicitly with the `Figure()` function, and set attributes of the underlying scene.
 The most important one of which is the `resolution`.
@@ -29,7 +29,7 @@ figure = figureaxisplot.figure
 figure, axis, plot = scatter(rand(100, 2))
 
 # you can also ignore components
-figure, _ = scatter(rand(100, 2))
+figure, = scatter(rand(100, 2))
 ```
 
 You can pass arguments to the created figure in a dict-like object to the special `figure` keyword:
@@ -38,10 +38,9 @@ You can pass arguments to the created figure in a dict-like object to the specia
 scatter(rand(100, 2), figure = (resolution = (600, 400),))
 ```
 
-## Placing Layoutables Into A Figure
+## Placing layoutables into a `Figure`
 
-All layoutables take their parent figure as the first argument, then you can place them in the figure layout
-via indexing syntax.
+All layoutables take their parent figure as the first argument, then you can place them in the figure layout via indexing syntax.
 
 ```julia
 f = Figure()
@@ -49,7 +48,7 @@ ax = f[1, 1] = Axis(f)
 sl = f[2, 1] = Slider(f)
 ```
 
-## FigurePositions and FigureSubpositions
+## `FigurePosition`s and `FigureSubposition`s
 
 The indexing syntax of `Figure` is implemented to work seamlessly with layouting.
 If you index into the figure, a `FigurePosition` object that stores this indexing operation is created.
@@ -100,7 +99,7 @@ All nested grid layouts that don't exist yet, but are needed for a nested plotti
     value for further manipulation. You can instead retrieve them after the fact with the `content` function, for example,
     as explained in the following section.
 
-## Retrieving Objects From A Figure
+## Retrieving objects from a `Figure`
 
 Sometimes users are surprised that indexing into a figure does not retrieve the object placed at that position.
 This is because the `FigurePosition` is needed for plotting, and returning content objects directly would take

--- a/docs/src/lighting.md
+++ b/docs/src/lighting.md
@@ -1,6 +1,6 @@
 # Lighting
 
-For 3-D scenes, GLMakie offers several attributes to control the lighting of the scene. These are set per plot.
+For 3D scenes, `GLMakie` offers several attributes to control the lighting of the scene. These are set per plot.
 
 - `ambient::Vec3f0`: Objects should never be completely dark; we use an ambient light to simulate background lighting, and give the object some color. Each element of the vector represents the intensity of color in R, G or B respectively.
 - `diffuse::Vec3f0`: Simulates the directional impact which the light source has on the plot object. This is the most visually significant component of the lighting model; the more a part of an object faces the light source, the brighter it becomes. Each element of the vector represents the intensity of color in R, G or B respectively.
@@ -27,7 +27,7 @@ GLMakie also implements [_screen-space ambient occlusion_](https://learnopengl.c
   a good compromise.
 
 !!! note
-The SSAO postprocessor is turned off by default to save on resources. To turn it on, set `GLMakie.enable_SSAO[] = true`, close any existing GLMakie window and reopen it.
+    The SSAO postprocessor is turned off by default to save on resources. To turn it on, set `GLMakie.enable_SSAO[] = true`, close any existing GLMakie window and reopen it.
 
 ## Matcap
 
@@ -38,7 +38,7 @@ A matcap (material capture) is a texture which is applied based on the normals o
 ```@example 1
 using GLMakie
 GLMakie.activate!() # hide
-using AbstractPlotting
+
 xs = -10:0.1:10
 ys = -10:0.1:10
 zs = [10 * (cos(x) * cos(y)) * (.1 + exp(-(x^2 + y^2 + 1)/10)) for x in xs, y in ys]

--- a/docs/src/makielayout/layoutables.md
+++ b/docs/src/makielayout/layoutables.md
@@ -1,23 +1,23 @@
-# Layoutables
+# `Layoutables`
 
 !!! note
     All examples in this section are presented as static CairoMakie vector graphics for clarity of visuals.
     Keep in mind that CairoMakie is not interactive.
     Use GLMakie for interactive widgets, as WGLMakie currently doesn't have picking implemented.
 
-Layoutables are objects which can be added to a Figure or Scene and have their location and size controlled by a `GridLayout`.
+`Layoutables` are objects which can be added to a `Figure` or `Scene` and have their location and size controlled by a `GridLayout`. In of itself, a `Layoutable` is an abstract type.
 A `Figure` has its own internal `GridLayout` and therefore offers simplified syntax for adding layoutables to it.
 If you want to work with a bare `Scene`, you can attach a `GridLayout` to its pixel area.
 The `layoutscene` function is supplied for this purpose.
 
 !!! note
     A layout only controls an object's position or bounding box.
-    A Layoutable can be controlled by the GridLayout of a Figure but not be added as a visual to the Figure.
-    A Layoutable can also be added to a Scene without being inside any GridLayout, if you specify the bounding box yourself.
+    A `Layoutable` can be controlled by the GridLayout of a Figure but not be added as a visual to the Figure.
+    A `Layoutable` can also be added to a Scene without being inside any GridLayout, if you specify the bounding box yourself.
 
-## Adding to a Figure
+## Adding to a `Figure`
 
-Here's one way to add a Layoutable, in this case an `Axis`, to a Figure.
+Here's one way to add a `Layoutable`, in this case an `Axis`, to a Figure.
 
 ```@example
 using CairoMakie
@@ -29,7 +29,7 @@ ax = Axis(f[1, 1])
 f
 ```
 
-## Adding to a Scene
+## Adding to a `Scene`
 
 And here's how you can add the same Layoutable to a Scene, which is the primitive object underlying a Figure.
 As discussed above, `layoutscene` is an older convenience method to create a Scene with an attached GridLayout that tracks its size.
@@ -47,7 +47,7 @@ scene
 
 ## Specifying a boundingbox directly
 
-Sometimes you just want to place a Layoutable in a specific location, without it being controlled by a dynamic layout.
+Sometimes you just want to place a `Layoutable` in a specific location, without it being controlled by a dynamic layout.
 You can do this by setting the `bbox` parameter, which is usually controlled by the layout, manually.
 The boundingbox should be a 2D `Rect`, and can also be an Observable if you plan to change it dynamically.
 The function `BBox` creates an `FRect2D`, but instead of passing origin and widths, you pass left, right, bottom and top boundaries directly.
@@ -65,6 +65,6 @@ Axis(f, bbox = BBox(400, 700, 200, 400), title = "Axis 2")
 f
 ```
 
-## Deleting Layoutables
+## Deleting layoutables
 
 To remove layoutables from their layout and the figure or scene, use `delete!(layoutable)`.

--- a/docs/src/makielayout/slider.md
+++ b/docs/src/makielayout/slider.md
@@ -25,9 +25,7 @@ fig = Figure(resolution = (1200, 900))
 ax = Axis(fig[1, 1])
 
 sl_x = Slider(fig[2, 1], range = 0:0.01:10, startvalue = 3)
-sl_y = Slider(fig[1, 2], range = 0:0.01:10, horizontal = false,
-    startvalue = 6,
-    tellwidth = true, height = nothing, width = Auto())
+sl_y = Slider(fig[1, 2], range = 0:0.01:10, horizontal = false, startvalue = 6)
 
 point = @lift(Point2f0($(sl_x.value), $(sl_y.value)))
 
@@ -56,7 +54,7 @@ lsgrid = labelslidergrid!(
     formats = [x -> "$(round(x, digits = 1))$s" for s in ["V", "A", "Ω"]],
     width = 350,
     tellheight = false)
-    
+
 fig[1, 2] = lsgrid.layout
 
 sliderobservables = [s.value for s in lsgrid.sliders]

--- a/docs/src/plot_method_signatures.md
+++ b/docs/src/plot_method_signatures.md
@@ -65,7 +65,7 @@ scatter!(scene, args...; kwargs...) -> ::Scatter
 
 ## FigurePositions
 
-In the background, each `Figure` has a `GridLayout` from GridLayoutBase.jl, which takes care of layouting plot elements nicely.
+In the background, each `Figure` has a `GridLayout` from [GridLayoutBase.jl](https://github.com/jkrumbiegel/GridLayoutBase.jl), which takes care of layouting plot elements nicely.
 For convenience, you can index into a figure multiple times to refer to nested grid positions, which makes it easy to quickly assemble complex layouts.
 
 For example, `fig[1, 2]` creates a `FigurePosition` referring to row 1 and column 2, while `fig[1, 2][3, 1:2]` creates a `FigureSubposition` that refers to row 3 and columns 1 to 2 in a nested GridLayout which is located at row 1 and column 2.

--- a/docs/src_generation/src-colors.md
+++ b/docs/src_generation/src-colors.md
@@ -15,7 +15,7 @@ Colormaps are mappings of values to colors. You can supply the coloring values u
 
 You can copy this code and substitute `cmap` with any `Colormap` to show the colormap.
 
-`Makie` supports multiple colormap libraries. Currently, support for colormaps provided by `PlotUtils` is inbuilt, meaning that any colormap symbol that works with Plots will also work with Makie. Colormaps from the `ColorSchemes` package can be used by `colormap = ColorSchemes.<name of colormap>.colors`. Similarly, colormaps from the `PerceptualColourMaps` package (which is a superset of the `colorcet` library) can be used by `colormap = PerceptualColourMaps.cgrad("<name of colormap>")`. In principle, any Array of `RGB` values can be used as a colormap.
+`Makie` supports multiple colormap libraries. Currently, support for colormaps provided by `PlotUtils` is inbuilt, meaning that any colormap symbol that works with `Plots` will also work with `Makie`. Colormaps from the `ColorSchemes` package can be used by `colormap = ColorSchemes.<name of colormap>.colors`. Similarly, colormaps from the `PerceptualColourMaps` package (which is a superset of the `colorcet` library) can be used by `colormap = PerceptualColourMaps.cgrad("<name of colormap>")`. In principle, any Array of `RGB` values can be used as a colormap.
 
 ### Builtins
 


### PR DESCRIPTION
- For consistency with other sections in the docs, markdown titles are sentence-cased
- Update the example code block in `Animating a plot "live"` to be a complete runnable example 
- Use `range`
