### PR TITLE
Add RegisterAction to help tagging

### DIFF
--- a/.github/workflows/RegisterAction.yml
+++ b/.github/workflows/RegisterAction.yml
@@ -1,0 +1,14 @@
+name: RegisterAction
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to register or component to bump
+        required: true
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/RegisterAction@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should help automate tagging even further

![image](https://user-images.githubusercontent.com/4319522/116316618-38786980-a780-11eb-92b3-7f153f7b1059.png)

This will update `Project.toml` to bump up the patch and trigger the Registeration bot!
