### PR TITLE
add default plottype to three vectors

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -555,6 +555,7 @@ plottype(::Type{Any}, argvalues...) = plottype(argvalues...)
 plottype(P::Type{<: Combined{T}}, argvalues...) where T = P
 
 ## specialized definitions for types
+plottype(::AbstractVector, ::AbstractVector, ::AbstractVector) = Scatter
 plottype(::AbstractVector, ::AbstractVector) = Scatter
 plottype(::AbstractVector) = Scatter
 plottype(::AbstractMatrix{<: Real}) = Heatmap


### PR DESCRIPTION
For consistency, given that `plot(rand(10), rand(10))` defaults to a scatter plot, then IMO `plot(rand(10), rand(10), rand(10))`  should default to a 3D scatter plot.