### PR TITLE
make density fill transparent

### DIFF
--- a/src/stats/density.jl
+++ b/src/stats/density.jl
@@ -29,7 +29,7 @@ $(ATTRIBUTES)
 """
 @recipe(Density) do scene
     Theme(
-        color = :gray85,
+        color = RGBAf0(0,0,0,0.2),
         strokecolor = :black,
         strokewidth = 1,
         strokearound = false,


### PR DESCRIPTION
I think this is generally better, to have the area under the curve be a transparent shade (I used the same default as `band`), otherwise when plotting multiple densities, they would hide each other.