### PR TITLE
Only deploydocs if the DOCUMENTER_KEY env variable is non-empty

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -407,7 +407,10 @@ makedocs(
 # env variable, which is JuliaPlots/AbstractPlotting.jl by default
 ENV["GITHUB_REPOSITORY"] = "JuliaPlots/MakieDocumentation"
 
-deploydocs(
-    repo = "github.com/JuliaPlots/MakieDocumentation",
-    push_preview = true
-)
+if !isempty(get(ENV, "DOCUMENTER_KEY", ""))
+    deploydocs(
+        repo = "github.com/JuliaPlots/MakieDocumentation",
+        push_preview = true
+    )
+end
+


### PR DESCRIPTION
This works around the `deploydocs` failure with PRs from users without write/admin permissions, where regardless of the docs building successfully the doc CI check automatically fails. 



