### PR TITLE
do not export `step!`

### DIFF
--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -230,7 +230,7 @@ export PlotSpec
 export plot!, plot
 
 
-export Stepper, step!, replay_events, record_events, RecordEvents, record, VideoStream
+export Stepper, replay_events, record_events, RecordEvents, record, VideoStream
 export VideoStream, recordframe!, record
 export save
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -127,6 +127,9 @@ Creates a Stepper for generating progressive plot examples.
 Each "step" is saved as a separate file in the folder
 pointed to by `path`, and the format is customizable by
 `format`, which can be any output type your backend supports.
+
+Notice that the relevant `AbstractPlotting.step!` is not
+exported and should be accessed by module name.
 """
 mutable struct FolderStepper
     scene::Scene


### PR DESCRIPTION
This is more like a discussion rather than a fix. In Slack I've raised the point that several Julia packages export step. The ones I know are DifferentialEquations.jl, DynamicalSystems.jl and Agents.jl. 

I'm not sure if the exported `step!` here is used somewhere, but I don't know either.