### PR TITLE
apply different conversion pipeline to heatmap

### DIFF
--- a/src/basic_recipes/contourf.jl
+++ b/src/basic_recipes/contourf.jl
@@ -39,7 +39,7 @@ function _get_isoband_levels(levels::AbstractVector{<:Real}, mi, ma)
     edges
 end
 
-conversion_trait(::Type{<:Contourf}) = SurfaceLike()
+conversion_trait(::Type{<:Contourf}) = ContinuousSurface()
 
 function AbstractPlotting.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:AbstractVector{<:Real}, <:AbstractMatrix{<:Real}}})
     xs, ys, zs = c[1:3]

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -71,8 +71,8 @@ function to_levels(n::Integer, cnorm)
     range(zmin + dz; step = dz, length = n)
 end
 
-conversion_trait(::Type{<: Contour3d}) = SurfaceLike()
-conversion_trait(::Type{<: Contour}) = SurfaceLike()
+conversion_trait(::Type{<: Contour3d}) = ContinuousSurface()
+conversion_trait(::Type{<: Contour}) = ContinuousSurface()
 conversion_trait(::Type{<: Contour{<: Tuple{X, Y, Z, Vol}}}) where {X, Y, Z, Vol} = VolumeLike()
 conversion_trait(::Type{<: Contour{<: Tuple{<: AbstractArray{T, 3}}}}) where T = VolumeLike()
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -249,7 +249,11 @@ function convert_arguments(P::PointBased, x::Rect3D)
     convert_arguments(P, decompose(Point3f0, x)[inds])
 end
 
-edges(v::AbstractVector) = edges(range(extrema(v)...; length=length(v)))
+function edges(v::AbstractVector)
+    l = length(v)
+    rg = l > 1 ? range(extrema(v)...; length=l) : range(extrema(v)...; step=1)
+    return edges(rg)
+end
 
 function edges(centers::AbstractRange)
     min, s, l = minimum(centers), step(centers), length(centers)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -251,13 +251,17 @@ end
 
 function edges(v::AbstractVector)
     l = length(v)
-    rg = l > 1 ? range(extrema(v)...; length=l) : range(extrema(v)...; step=1)
-    return edges(rg)
-end
-
-function edges(centers::AbstractRange)
-    min, s, l = minimum(centers), step(centers), length(centers)
-    return range(min - s / 2, step=s, length=l + 1)
+    if l == 1
+        return [v[1] - 0.5, v[1] + 0.5]
+    else
+        # Equivalent to
+        # mids = 0.5 .* (v[1:end-1] .+ v[2:end])
+        # borders = [2v[1] - mids[1]; mids; 2v[end] - mids[end]]
+        borders = [0.5 * (v[max(1, i)] + v[min(end, i+1)]) for i in 0:length(v)]
+        borders[1] = 2borders[1] - borders[2]
+        borders[end] = 2borders[end] - borders[end-1]
+        return borders
+    end
 end
 
 function adjust_axes(::DiscreteSurface, x::AbstractVector{<:Number}, y::AbstractVector{<:Number}, z::AbstractMatrix)


### PR DESCRIPTION
This follows the suggestion at https://github.com/JuliaPlots/Makie.jl/issues/748, that the conversion pipeline should not be the same for `Heatmap` and `Contour, Conturf, Surface`. I've created two different traits, `DiscreteSurface` for the `Heatmap` and `ContinuousSurface` for the others (happy to switch to `CellSurfaceLike` and `VertexSurfaceLike` if those are clearer names).

For now the only difference is that `heatmap(1:3, 1:3, rand(3, 3))` gets converted to `heatmap(0.5:3.5, 0.5:3.5, rand(3, 3))`, so that now `heatmap(1:3, 1:3, rand(3, 3))` is consistent with Plots, see https://github.com/JuliaPlots/Makie.jl/issues/661.

This to me counts as "bug fix" as the current implementation of `heatmap(1:3, 1:3, rand(3, 3))`, ie split the interval `1..3` in 3 bins of length `0.66`, is IMO not correct. I'm not sure if the `(x::Vector, y::Vector, z::Matrix)` case is the only one that needs special-casing for `DiscreteSurface` or if there are others.