### PR TITLE
Allow vector offsets in text

### DIFF
--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -231,12 +231,15 @@ function glyph_positions(str::AbstractString, font_per_char, fontscale_px, halig
         reduce(vcat, map(line -> [l.hadvance for l in line], lineinfos)))
 end
 
-function preprojected_glyph_arrays(string::String, position::VecTypes, glyphlayout::AbstractPlotting.Glyphlayout, font, textsize, space::Symbol, projview, resolution, offset::VecTypes, transfunc)
+
+function preprojected_glyph_arrays(
+        string::String, position::VecTypes, glyphlayout::AbstractPlotting.Glyphlayout, 
+        font, textsize, space::Symbol, projview, resolution, offset::VecTypes, transfunc
+    )
 
     offset = to_ndim(Point3f0, offset, 0)
     pos3f0 = to_ndim(Point3f0, position, 0)
 
-    atlas = get_texture_atlas()
     if space == :data
         positions = apply_transform(transfunc, [pos3f0 + offset + o for o in glyphlayout.origins])
     elseif space == :screen
@@ -246,20 +249,35 @@ function preprojected_glyph_arrays(string::String, position::VecTypes, glyphlayo
         error("Unknown space $space, only :data or :screen allowed")
     end
 
-    uv = Vec4f0[]
-    scales = Vec2f0[]
-    offsets = Vec2f0[]
-    for (c, font, pixelsize) in zip(string, attribute_per_char(string, font), attribute_per_char(string, textsize))
-        push!(uv, glyph_uv_width!(atlas, c, font))
-        glyph_bb, extent = FreeTypeAbstraction.metrics_bb(c, font, pixelsize)
-        push!(scales, widths(glyph_bb))
-        push!(offsets, minimum(glyph_bb))
-    end
-    return positions, offsets, uv, scales
+    text_quads(positions, string, font, textsize)
 end
 
 
-function preprojected_glyph_arrays(strings::AbstractVector{<:String}, positions::AbstractVector, glyphlayouts::Vector, font, textsize, space::Symbol, projview, resolution, offset, transfunc)
+function preprojected_glyph_arrays(
+        string::String, position::VecTypes, glyphlayout::AbstractPlotting.Glyphlayout, 
+        font, textsize, space::Symbol, projview, resolution, offsets::Vector, transfunc
+    )
+
+    offsets = to_ndim.(Point3f0, offsets, 0)
+    pos3f0 = to_ndim(Point3f0, position, 0)
+
+    if space == :data
+        positions = apply_transform(transfunc, [pos3f0 + offset + o for (o, offset) in zip(glyphlayout.origins, offsets)])
+    elseif space == :screen
+        projected = AbstractPlotting.project(projview, resolution, apply_transform(transfunc, pos3f0))
+        positions = [to_ndim(Point3f0, projected, 0) + offset + o for (o, offset) in zip(glyphlayout.origins, offsets)]
+    else
+        error("Unknown space $space, only :data or :screen allowed")
+    end
+
+    text_quads(positions, string, font, textsize)
+end
+
+
+function preprojected_glyph_arrays(
+        strings::AbstractVector{<:String}, positions::AbstractVector, glyphlayouts::Vector, font, 
+        textsize, space::Symbol, projview, resolution, offset, transfunc
+    )
 
     if offset isa VecTypes
         offset = [to_ndim(Point3f0, offset, 0)]
@@ -293,6 +311,62 @@ function preprojected_glyph_arrays(strings::AbstractVector{<:String}, positions:
         error("Unknown space $space, only :data or :screen allowed")
     end
 
+    text_quads(allpos, strings, font, textsize)
+end
+
+
+function preprojected_glyph_arrays(
+        strings::AbstractVector{<:String}, positions::AbstractVector, glyphlayouts::Vector, font, 
+        textsize, space::Symbol, projview, resolution, offsets::Vector{<: Vector}, transfunc
+    )
+
+    megastring = join(strings, "")
+
+    if space == :data
+        allpos = broadcast(positions, glyphlayouts, offsets) do pos, glyphlayout::AbstractPlotting.Glyphlayout, offsets
+            p = to_ndim(Point3f0, pos, 0)
+            apply_transform(
+                transfunc,
+                [p .+ to_ndim(Point3f0, offset, 0) .+ o for (o, offset) in zip(glyphlayout.origins, offsets)]
+            )
+        end
+    elseif space == :screen
+        allpos = broadcast(positions, glyphlayouts, offsets) do pos, glyphlayout::AbstractPlotting.Glyphlayout, offsets
+            projected = to_ndim(
+                Point3f0,
+                AbstractPlotting.project(
+                    projview,
+                    resolution,
+                    apply_transform(transfunc, to_ndim(Point3f0, pos, 0))
+                ),
+                0)
+
+            return [projected .+ to_ndim(Point3f0, offset, 0) + o for (o, offset) in zip(glyphlayout.origins, offsets)]
+        end
+    else
+        error("Unknown space $space, only :data or :screen allowed")
+    end
+
+    text_quads(allpos, strings, font, textsize)
+end
+
+
+function text_quads(positions, string::String, font, textsize)
+    atlas = get_texture_atlas()
+    offsets = Vec2f0[]
+    uv = Vec4f0[]
+    scales = Vec2f0[]
+    for (c, font, pixelsize) in zip(string, attribute_per_char(string, font), attribute_per_char(string, textsize))
+        push!(uv, glyph_uv_width!(atlas, c, font))
+        glyph_bb, extent = FreeTypeAbstraction.metrics_bb(c, font, pixelsize)
+        push!(scales, widths(glyph_bb))
+        push!(offsets, minimum(glyph_bb))
+    end
+    return positions, offsets, uv, scales
+end
+
+
+function text_quads(allpos::Vector, strings::Vector, font, textsize)
     megapos::Vector{Point3f0} = if isempty(allpos)
         Point3f0[]
     else
@@ -300,9 +374,9 @@ function preprojected_glyph_arrays(strings::AbstractVector{<:String}, positions:
     end
 
     atlas = get_texture_atlas()
+    offsets = Vec2f0[]
     uv = Vec4f0[]
     scales = Vec2f0[]
-    offsets = Vec2f0[]
 
     broadcast_foreach(strings, font, textsize) do str, fo, ts
         for (c, f, pixelsize) in zip(str, attribute_per_char(str, fo), attribute_per_char(str, ts))


### PR DESCRIPTION
This doesn't break anything as far as I can tell, but it allows you to do some hacky super- and subscript as well as (one character) fractions.

```julia
scene = Scene()
text!(
    scene,
    ["kx", "π_2"],
    position = [Point3f0(1, 0.5, 0.5), Point3f0(0.5, 1, 0.25)],
    offset = [
        [Vec2f0(0), Vec2f0(0, -5)],
        [Vec2f0(0, 10), Vec2f0(-11, 11), Vec2f0(-22, -11)],
    ]
)
scene |> display
```

![Screenshot from 2021-05-03 23-19-34](https://user-images.githubusercontent.com/10947937/116935021-0bd3be80-ac66-11eb-9025-1aabbab5c912.png)
