### PR TITLE
support datalimits and respect area in violin

### DIFF
--- a/docs/src/plotting_functions/violin.md
+++ b/docs/src/plotting_functions/violin.md
@@ -42,7 +42,7 @@ xs = rand(1:3, N)
 dodge = rand(1:2, N)
 side = rand([:left, :right], N)
 colors = map(side) do s
-    return s == :left ? RGB(0.0, 0.5, 0.5) : RGB(1.0, 0.65, 0.0)
+    return s == :left ? "orange" : "teal"
 end
 ys = map(side) do s
     return s == :left ? randn() : rand()

--- a/docs/src/plotting_functions/violin.md
+++ b/docs/src/plotting_functions/violin.md
@@ -41,12 +41,26 @@ N = 1000
 xs = rand(1:3, N)
 dodge = rand(1:2, N)
 side = rand([:left, :right], N)
-colors = map(side) do s
-    return s == :left ? "orange" : "teal"
-end
+color = Observable((left = :orange, right = :teal))
 ys = map(side) do s
     return s == :left ? randn() : rand()
 end
 
-violin(xs, ys, dodge = dodge, side = side, color = colors)
+violin(xs, ys, dodge = dodge, side = side, color = color)
+```
+
+```@example
+using CairoMakie
+CairoMakie.activate!() # hide
+AbstractPlotting.inline!(true) # hide
+
+N = 1000
+xs = rand(1:3, N)
+side = rand([:left, :right], N)
+color = Observable((left = [:red, :orange, :yellow], right = [:blue, :teal, :cyan]))
+ys = map(side) do s
+    return s == :left ? randn() : rand()
+end
+
+violin(xs, ys, side = side, color = color)
 ```

--- a/docs/src/plotting_functions/violin.md
+++ b/docs/src/plotting_functions/violin.md
@@ -41,7 +41,7 @@ N = 1000
 xs = rand(1:3, N)
 dodge = rand(1:2, N)
 side = rand([:left, :right], N)
-color = Observable((left = :orange, right = :teal))
+color = @. ifelse(side == :left, :orange, :teal)
 ys = map(side) do s
     return s == :left ? randn() : rand()
 end
@@ -57,7 +57,10 @@ AbstractPlotting.inline!(true) # hide
 N = 1000
 xs = rand(1:3, N)
 side = rand([:left, :right], N)
-color = Observable((left = [:red, :orange, :yellow], right = [:blue, :teal, :cyan]))
+color = map(xs, side) do x, s
+    colors = s == :left ? [:red, :orange, :yellow] : [:blue, :teal, :cyan]
+    return colors[x]
+end
 ys = map(side) do s
     return s == :left ? randn() : rand()
 end

--- a/docs/src/plotting_functions/violin.md
+++ b/docs/src/plotting_functions/violin.md
@@ -17,22 +17,36 @@ ys = randn(1000)
 violin(xs, ys)
 ```
 
+
 ```@example
 using CairoMakie
 CairoMakie.activate!() # hide
 AbstractPlotting.inline!(true) # hide
 
-xs1 = rand(1:3, 1000)
-ys1 = randn(1000)
-dodge1 = rand(1:2, 1000)
+xs = rand(1:3, 1000)
+ys = map(xs) do x
+    return x == 1 ? randn() : x == 2 ? 0.5 * randn() : 5 * rand()
+end
 
-xs2 = rand(1:3, 1000)
-ys2 = randn(1000)
-dodge2 = rand(1:2, 1000)
+violin(xs, ys, datalimits = extrema)
+```
 
-fig = Figure()
-ax = Axis(fig[1, 1])
-violin!(ax, xs1, ys1, dodge = dodge1, side = :left, color = :orange)
-violin!(ax, xs2, ys2, dodge = dodge2, side = :right, color = :teal)
-fig
+
+```@example
+using CairoMakie
+CairoMakie.activate!() # hide
+AbstractPlotting.inline!(true) # hide
+
+N = 1000
+xs = rand(1:3, N)
+dodge = rand(1:2, N)
+side = rand([:left, :right], N)
+colors = map(side) do s
+    return s == :left ? RGB(0.0, 0.5, 0.5) : RGB(1.0, 0.65, 0.0)
+end
+ys = map(side) do s
+    return s == :left ? randn() : rand()
+end
+
+violin(xs, ys, dodge = dodge, side = side, color = colors)
 ```

--- a/src/stats/violin.jl
+++ b/src/stats/violin.jl
@@ -46,8 +46,9 @@ function plot!(plot::Violin)
             return s == :left ? - 1 : s == :right ? 1 : 0
         end
         colors = broadcast(x̂, color) do _, c
+            rgba = to_color(c)
             # `RGBA` values cannot be sorted
-            return rgbatuple(c)
+            return (red(rgba), green(rgba), blue(rgba), alpha(rgba))
         end
 
         sa = StructArray((x = x̂, side = sides, color = colors))

--- a/src/stats/violin.jl
+++ b/src/stats/violin.jl
@@ -46,9 +46,8 @@ function plot!(plot::Violin)
             return s == :left ? - 1 : s == :right ? 1 : 0
         end
         colors = broadcast(x̂, color) do _, c
-            rgba = to_color(c)
             # `RGBA` values cannot be sorted
-            return (rgba.r, rgba.g, rgba.b, rgba.alpha)
+            return rgbatuple(c)
         end
 
         sa = StructArray((x = x̂, side = sides, color = colors))

--- a/src/stats/violin.jl
+++ b/src/stats/violin.jl
@@ -113,16 +113,19 @@ function plot!(plot::Violin)
         return (vertices = vertices, lines = lines, colors = colors)
     end
 
-    t = copy(Theme(plot))
-    mediancolor = pop!(t, :mediancolor)
-    t[:color] = lift(s -> s.colors, signals)
-    poly!(plot, t, lift(s -> s.vertices, signals))
+    poly!(
+        plot,
+        lift(s -> s.vertices, signals),
+        color = lift(s -> s.colors, signals),
+        strokecolor = plot[:strokecolor],
+        strokewidth = plot[:strokewidth],
+    )
     linesegments!(
         plot,
         lift(s -> s.lines, signals),
         color = lift(
             (mc, sc) -> mc === automatic ? sc : mc,
-            mediancolor,
+            plot[:mediancolor],
             plot[:strokecolor],
         ),
         linewidth = plot[:medianlinewidth],

--- a/src/stats/violin.jl
+++ b/src/stats/violin.jl
@@ -8,6 +8,8 @@ Draw a violin plot.
 - `orientation=:vertical`: orientation of the violins (`:vertical` or `:horizontal`)
 - `width=0.8`: width of the violin
 - `show_median=true`: show median as midline
+- `side=:both`: specify `:left` or `:right` to only plot the violin on one side
+- `datalimits`: specify values to trim the `violin`. Can be a `Tuple` or a `Function` (e.g. `datalimits=extrema`)
 """
 @recipe(Violin, x, y) do scene
     Theme(;
@@ -21,7 +23,8 @@ Draw a violin plot.
         n_dodge = automatic,
         x_gap = 0.2,
         dodge_gap = 0.03,
-        trim = false,
+        datalimits = (-Inf, Inf),
+        max_density = automatic,
         strokecolor = :white,
         show_median = false,
         mediancolor = automatic,
@@ -32,32 +35,60 @@ end
 conversion_trait(x::Type{<:Violin}) = SampleBased()
 
 function plot!(plot::Violin)
-    x, y, width, side, show_median = plot[1], plot[2], plot[:width], plot[:side], plot[:show_median]
-    npoints, boundary, bandwidth = plot[:npoints], plot[:boundary], plot[:bandwidth]
-    dodge, n_dodge, x_gap, dodge_gap = plot[:dodge], plot[:n_dodge], plot[:x_gap], plot[:dodge_gap]
-
-    signals = lift(x, y, width, dodge, n_dodge, x_gap, dodge_gap, side, show_median, npoints, boundary, bandwidth) do x, y, width, dodge, n_dodge, x_gap, dodge_gap, vside, show_median, n, bound, bw
+    x, y = plot[1], plot[2]
+    args = @extract plot (width, side, color, show_median, npoints, boundary, bandwidth,
+        datalimits, max_density, dodge, n_dodge, x_gap, dodge_gap)
+    signals = lift(x, y, args...) do x, y, width, side, color, show_median, n, bound, bw, limits, max_density, dodge, n_dodge, x_gap, dodge_gap
         x̂, violinwidth = xw_from_dodge(x, width, 1, x_gap, dodge, n_dodge, dodge_gap)
-        vertices = Vector{Point2f0}[]
-        lines = Pair{Point2f0, Point2f0}[]
-        for (key, idxs) in StructArrays.finduniquesorted(x̂)
+
+        # Allow `side` and `color` to be either scalar or vector
+        sides = broadcast(x̂, side) do _, s
+            return s == :left ? - 1 : s == :right ? 1 : 0
+        end
+        colors = broadcast(x̂, color) do _, c
+            rgba = to_color(c)
+            # `RGBA` values cannot be sorted
+            return (rgba.r, rgba.g, rgba.b, rgba.alpha)
+        end
+
+        sa = StructArray((x = x̂, side = sides, color = colors))
+
+        specs = map(StructArrays.finduniquesorted(sa)) do (key, idxs)
             v = view(y, idxs)
             k = KernelDensity.kde(v;
                 npoints = n,
                 (bound === automatic ? NamedTuple() : (boundary = bound,))...,
                 (bw === automatic ? NamedTuple() : (bandwidth = bw,))...,
             )
-            spec = (x = key, kde = k, median = median(v))
-            min, max = extrema_nan(spec.kde.density)
+            l1, l2 = limits isa Function ? limits(v) : limits
+            i1, i2 = searchsortedfirst(k.x, l1), searchsortedlast(k.x, l2)
+            kde = (x = view(k.x, i1:i2), density = view(k.density, i1:i2))
+            return (x = key.x, side = key.side, color = RGBA(key.color...), kde = kde, median = median(v))
+        end
+
+        max = if max_density === automatic
+            maximum(specs) do spec
+                _, max = extrema_nan(spec.kde.density)
+                return max
+            end
+        else
+            max_density
+        end
+
+        vertices = Vector{Point2f0}[]
+        lines = Pair{Point2f0, Point2f0}[]
+        colors = RGBA{Float32}[]
+
+        for spec in specs
             scale = 0.5*violinwidth/max
             xl = reverse(spec.x .- spec.kde.density .* scale)
             xr = spec.x .+ spec.kde.density .* scale
             yl = reverse(spec.kde.x)
             yr = spec.kde.x
 
-            x_coord, y_coord = if vside == :left
+            x_coord, y_coord = if spec.side == -1 # left violin
                 [spec.x; xl; spec.x], [yl[1]; yl; yl[end]]
-            elseif vside == :right
+            elseif spec.side == 1 # right violin
                 [spec.x; xr; spec.x], [yr[1]; yr; yr[end]]
             else
                 [spec.x; xr; spec.x; xl], [yr[1]; yr; yl[1]; yl]
@@ -72,19 +103,23 @@ function plot!(plot::Violin)
                 ym₋, ym₊ = spec.kde.density[ip-1], spec.kde.density[ip]
                 xm₋, xm₊ = spec.kde.x[ip-1], spec.kde.x[ip]
                 ym = (xm * (ym₊ - ym₋) + xm₊ * ym₋ - xm₋ * ym₊) / (xm₊ - xm₋)
-                median_left = Point2f0(vside == :right ? spec.x : spec.x - ym * scale, xm)
-                median_right = Point2f0(vside == :left ? spec.x : spec.x + ym * scale, xm)
+                median_left = Point2f0(spec.side == 1 ? spec.x : spec.x - ym * scale, xm)
+                median_right = Point2f0(spec.side == -1 ? spec.x : spec.x + ym * scale, xm)
                 push!(lines, median_left => median_right)
             end
+            push!(colors, spec.color)
         end
-        return vertices, lines
+
+        return (vertices = vertices, lines = lines, colors = colors)
     end
+
     t = copy(Theme(plot))
     mediancolor = pop!(t, :mediancolor)
-    poly!(plot, t, lift(first, signals))
+    t[:color] = lift(s -> s.colors, signals)
+    poly!(plot, t, lift(s -> s.vertices, signals))
     linesegments!(
         plot,
-        lift(last, signals),
+        lift(s -> s.lines, signals),
         color = lift(
             (mc, sc) -> mc === automatic ? sc : mc,
             mediancolor,


### PR DESCRIPTION
From a discussion on discourse (https://discourse.julialang.org/t/side-by-side-violin-plots-with-vegalite-jl/60523/2?u=piever) as well as a conversation on slack (copied below to avoid losing it), it seems like user expects violin plots to be renormalized _together_, in that all densities are rescaled by the same factor to fit in the allocated width.

This PR allows to pass both sides together in order to normalize correctly, and allows "trimming options" (as in `datalimits=(0, Inf)` or `datalimits=extrema`).

Main issue is that this way both sides of the violin have to be plotted in the same call (to be able to figure out the correct rescaling factor).

Main issues so far:
-  Cairo drawing `poly!` with a vector of colors (as many as there are polygons) seems very slow.
- ~GLMakie somehow has trouble drawing the `poly!` with different colors (one per polygon), and draws them transparent, really not sure why~ (ups, had the wrong AbstractPlotting checked out, things actually work fine in GLMakie)

cc: @sethaxen @yakir12

## Slack chat for posterity

> I have another "renormalization" question about statistical data visualization. It seems that both StatsPlots and Makie plot violins by renormalizing the density of each category so that the maximum is the maximum of the "violin width" https://user-images.githubusercontent.com/16589944/98538614-506c3780-228b-11eb-881c-158c2f781798.png, whereas it looks to me as if ggplot2 renormalizes by a global quantity, so that different categories can be shown with different widths: https://ggplot2.tidyverse.org/reference/geom_violin-1.png
> question 1) Are both renormalization strategies acceptable, or are there strong reasons in favor of one or the other?
> question 2) I was planning to implement ridge density plots, and was curious: if we keep the renormalization by category approach for violins, should we also renormalize by category in ridge plots?
> 
> (47 kB)
> https://user-images.githubusercontent.com/16589944/98538614-506c3780-228b-11eb-881c-158c2f781798.png
> 
> 
> (69 kB)
> https://ggplot2.tidyverse.org/reference/geom_violin-1.png
> 
> 
> Seth Axen:axe:  16 hours ago
> My two cents: it's important that one unit area corresponds to the same amount of probability mass for each violin, which allows easy visual comparison of the violins. So I guess I prefer ggplot's approach. How would StatsPlots and Makie plot the second version?
> 
> Pietro Vertechi  15 hours ago
> so I guess even in a side by side violin (this just popped up https://discourse.julialang.org/t/side-by-side-violin-plots-with-vegalite-jl/60523/2?u=piever) both sides should have equal area? We may need to change the implementation a bit then, because one can no longer plot left and right side separately (edited) 
> 
> JuliaLangJuliaLang
> Side by side violin plots with VegaLite.jl
> A promising alternative is using split violins in CairoMakie using CairoMakie xs1 = rand(["a", "b", "c"], 1000) ys1 = randn(1000) dodge1 = rand(1:2, 1000) xs2 = rand(["a", "b", "c"], 1000) ys2 = randn(1000) dodge2 = rand(1:2, 1000) fig = Figure() ax = Axis(fig[1, 1]) violin!(ax, xs1, ys1, dodge = dodge1, side = :left, color = "orange") violin!(ax, xs2, ys2, dodge = dodge2, side = :right, color = "teal") fig which produces Looks nice, I think. However, with my actual data, it looks like ...
> Yesterday at 5:15 PM
> 
> Pietro Vertechi  15 hours ago
> (looks like ggplot trims the violin by default, not 100% sure that's a good idea)
> 
> Pietro Vertechi  15 hours ago
> (related question: should the area / probability mass ratio be respected also across different subplots of the same facet?)
> 
> Yakir Gagnon:computer:  4 hours ago
> Just plotted violins, I also find it irritating that the smoothing function extends the data across the y-axis which makes it look like there is data below and above the data's extrema. This is problematic if the data is by definition all positive (e.g. body height) and due to some data close to zero the violin spills below zero: impossible.
> 
> Seth Axen:axe:  3 hours ago
> so I guess even in a side by side violin (this just popped up https://discourse.julialang.org/t/side-by-side-violin-plots-with-vegalite-jl/60523/2?u=piever) both sides should have equal area?
> This gets to a deeper issue: what is the area that a violin plot is representing? e.g. if its representing probability mass, and two categories are shown on the two sides, then yes, the two sides should have the same area. But if the area is meant to represent proportion of a population, and the categories have two different total populations, then it might make sense to use different areas for the two sides. This is something that ggplot doesn't do. The first 3 pages of http://www.mjskay.com/papers/chi2020-pgog.pdf is a nice read on this.
> 
> Seth Axen:axe:  3 hours ago
> (looks like ggplot trims the violin by default, not 100% sure that's a good idea)
> Just plotted violins, I also find it irritating that the smoothing function extends the data across the y-axis which makes it look like there is data below and above the data's extrema.
> I also prefer truncated violins by default. The tails can easily be misleading, since they extend outside the data range. This is why both the plots implemented in ArviZ.jl and MCMCChains.jl default to truncating to the data range.
> 
> Yakir Gagnon:computer:  2 hours ago
> So ideally, a histogram-related function should allow for controlling all these options... i.e.:
> truncated = true, mass = true, ...
> I thought one of the hist-plotting functions did that somewhere, I remember this being discussed somewhere already...
> 
> Pietro Vertechi  2 hours ago
> I asked about this in the case of normalized stack histogram, where for now we conform to ggplot (normalize by class), which seems to be in disagreement with the reference above. There, it is even trickier, because for stacked bars, the reference above makes sense (color the whole by category), but for dodged bars (or bars in different subplots of a facet) it is less intuitive.
> The API will have to be trickier than mass = true, you basically need to specify how to group for renormalization purposes. The simplest may probably be based on data-format: different columns are normalized separately, the same column split by a categorical variable is normalized together.
> 
> Yakir Gagnon:computer:  2 hours ago
> omg
> 
> Yakir Gagnon:computer:  2 hours ago
> amazing work :slightly_smiling_face:
> 
> Pietro Vertechi  2 hours ago
> Re: truncation, there is a trim = false setting that accidentally no longer works, but can be easily fixed. I confess I think I'm not in favor of trimming, as it becomes less clear what you are plotting. It is no longer "the convolution of my data distribution with a Gaussian", but becomes "the convolution of my data distribution with a Gaussian, unless the point is outside the empirical extrema of my distribution, in which case return zero".
> It becomes even messier when you normalize together different categories: should we now trim according to the extrema of the whole data or just one category? Maybe a good compromise is to allow the user to pass explicit trimming values (eg, trim = (0, Inf) if you know the variable is positive).
> 
> 
> 
> 
> Yakir Gagnon:computer:  2 hours ago
> I vote for the latter, I mean, I only care if the resulting hist shows an unrealistic distribution. So while the resulting hist is not a predefined distribution (Normal etc), I would like to have a convolution+rules.