### PR TITLE
Added method example to axislegend

### DIFF
--- a/src/makielayout/layoutables/legend.jl
+++ b/src/makielayout/layoutables/legend.jl
@@ -499,6 +499,7 @@ axislegend(title::String; kwargs...) = axislegend(current_axis(), current_axis()
 
 """
     axislegend(ax, args...; position = :rt, kwargs...)
+    axislegend(ax, args...; position = (1, 1), kwargs...)
     axislegend(ax = current_axis(); kwargs...)
     axislegend(title::String; kwargs...)
 


### PR DESCRIPTION
In this PR, I added the method example `axislegend(ax, args...; position = (1, 1), kwargs...)`

The motivation is that I went to try the function just now, and initially started inputing numbers on the size-scale of pixels, because i was not familiar with halign and valign, and the fact that they go from 0 to 1. So I figured that adding this example would potentialy clarify thing for people like me.