### PR TITLE
change default heatmap bounds to be centered

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -335,6 +335,12 @@ function convert_arguments(::SurfaceLike, data::AbstractMatrix)
     (0f0 .. n, 0f0 .. m, el32convert(data))
 end
 
+function convert_arguments(::DiscreteSurface, data::AbstractMatrix)
+    n, m = Float32.(size(data))
+    (0.5f0 .. n+0.5f0, 0.5f0 .. m+0.5f0, el32convert(data))
+end
+
+
 """
     convert_arguments(P, x, y, f)::(Vector, Vector, Matrix)
 


### PR DESCRIPTION
With this `heatmap(rand(10, 10))` produces:
![Screenshot from 2021-05-08 15-32-13](https://user-images.githubusercontent.com/10947937/117541111-a5a6bd00-b012-11eb-8417-d033bb6ec24c.png)
