### PR TITLE
add rotation/s to Billboard

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -752,7 +752,8 @@ function convert_attribute(c::Tuple{T, F}, k::key"color") where {T, F <: Number}
     RGBAf0(Colors.color(to_color(c[1])), c[2])
 end
 
-convert_attribute(c::Billboard, ::key"rotations") = Quaternionf0(0, 0, 0, 1)
+convert_attribute(b::Billboard{Float32}, ::key"rotations") = to_rotation(b.rotation)
+convert_attribute(b::Billboard{Vector{Float32}}, ::key"rotations") = to_rotation.(b.rotation)
 convert_attribute(r::AbstractArray, ::key"rotations") = to_rotation.(r)
 convert_attribute(r::StaticVector, ::key"rotations") = to_rotation(r)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -296,10 +296,18 @@ func2type(f::Function) = Combined{f}
 
 
 """
+    Billboard([angle::Real])
+    Billboard([angles::Vector{<: Real}])
+
 Billboard attribute to always have a primitive face the camera.
 Can be used for rotation.
 """
-struct Billboard end
+struct Billboard{T <: Union{Float32, Vector{Float32}}}
+    rotation::T
+end
+Billboard() = Billboard(0f0)
+Billboard(angle::Real) = Billboard(Float32(angle))
+Billboard(angles::Vector) = Billboard(Float32.(angles))
 
 """
 Type to indicate that an attribute will get calculated automatically


### PR DESCRIPTION
Requires JuliaPlots/GLMakie.jl/pull/189, JuliaPlots/CairoMakie.jl#160 and JuliaPlots/WGLMakie.jl#99

Adds an angle to `Billboard` to allow for in-plane rotations. Should help with #720.