### PR TITLE
Switch to using `Artifacts` for `assets/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ phases.0001_print.jpg
 **/._*
 Manifest.toml
 !docs/Manifest.toml
+/build
 
 \.DS_Store

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2,5 +2,5 @@
 git-tree-sha1 = "a74800f299f6bdade309e459b999442f303aa64d"
 
     [[assets.download]]
-    sha256 = "7ccfd273ff2ac996059d9019ff317202bdc69aef394fe450be557df9aae81733"
+    sha256 = "aa8d3e891da5c0757620f0bad9f9cd78e2e843bbc31773b5759e4f54e4f92b2b"
     url = "https://github.com/JuliaPlots/AbstractPlotting.jl/releases/download/assets-0.1.0/assets-0.1.0.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,6 @@
+[assets]
+git-tree-sha1 = "a74800f299f6bdade309e459b999442f303aa64d"
+
+    [[assets.download]]
+    sha256 = "7ccfd273ff2ac996059d9019ff317202bdc69aef394fe450be557df9aae81733"
+    url = "https://github.com/JuliaPlots/AbstractPlotting.jl/releases/download/assets-0.1.0/assets-0.1.0.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.18.2"
 
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 ColorBrewer = "a2cac450-b92f-5266-8821-25eda20663c8"
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/artifacts.jl
+++ b/artifacts.jl
@@ -1,33 +1,63 @@
 # Artifact generator for the assets directory.
+#
+# Requires:
+#
+#   - A github token stored in `ENV["GITHUB_AUTH"]` with access to `repo` read/write.
+#   - Extra packages: `ghr_jll` for release uploading.
+#
+# Usage:
+#
+#   - Update files in `/assets` directory.
+#   - Bump the `version` variable below.
+#   - Run `rebuild_artifacts()` to create new tarball and update Artifacts.toml.
+#   - Commit the changes.
+#   - Run `release_artifacts()` to create a new release and upload the new tarball.
+#
 
 using Pkg.Artifacts
-using URIs
+using ghr_jll
+using LibGit2
 
 version = v"0.1.0"
-host = "https://github.com/JuliaPlots/AbstractPlotting.jl/releases/download"
+user = "JuliaPlots"
+repo = "AbstractPlotting.jl"
+host = "https://github.com/$user/$repo/releases/download"
 
 build_path = joinpath(@__DIR__, "build")
+assets_path = joinpath(@__DIR__, "assets")
+artifact_toml = joinpath(@__DIR__, "Artifacts.toml")
 
-ispath(build_path) && rm(build_path, force=true, recursive=true)
-mkpath(build_path)
+function rebuild_artifacts()
+    ispath(build_path) && rm(build_path, force=true, recursive=true)
+    mkpath(build_path)
 
-product_hash = create_artifact() do artifact_dir
-    cp(joinpath(@__DIR__, "assets"), artifact_dir; force = true)
+    product_hash = create_artifact() do artifact_dir
+        cp(assets_path, artifact_dir; force = true)
+    end
+
+    archive_filename = "assets-$version.tar.gz"
+    download_hash = archive_artifact(product_hash, joinpath(build_path, archive_filename))
+
+    bind_artifact!(
+        artifact_toml,
+        "assets",
+        product_hash,
+        force = true,
+        download_info = Tuple[
+            (
+                "$host/assets-$version/$archive_filename",
+                download_hash,
+            ),
+        ],
+    )
 end
 
-archive_filename = "assets-$version.tar.gz"
-artifact_toml = joinpath(@__DIR__, "Artifacts.toml")
-download_hash = archive_artifact(product_hash, joinpath(build_path, archive_filename))
-
-bind_artifact!(
-    artifact_toml,
-    "assets",
-    product_hash,
-    force = true,
-    download_info = Tuple[
-        (
-            "$host/assets-$(escapeuri(string(version)))/$archive_filename",
-            download_hash,
-        ),
-    ],
-)
+function release_artifacts()
+    name = "Release assets $(version)"
+    commit = string(LibGit2.GitHash(LibGit2.GitCommit(LibGit2.GitRepo(@__DIR__), "HEAD")))
+    token = ENV["GITHUB_AUTH"]
+    tag = "assets-$version"
+    ghr() do bin
+        run(`$bin -u $user -r $repo -n $name -c $commit -t $token $tag $build_path`)
+    end
+end

--- a/artifacts.jl
+++ b/artifacts.jl
@@ -1,0 +1,33 @@
+# Artifact generator for the assets directory.
+
+using Pkg.Artifacts
+using URIs
+
+version = v"0.1.0"
+host = "https://github.com/JuliaPlots/AbstractPlotting.jl/releases/download"
+
+build_path = joinpath(@__DIR__, "build")
+
+ispath(build_path) && rm(build_path, force=true, recursive=true)
+mkpath(build_path)
+
+product_hash = create_artifact() do artifact_dir
+    cp(joinpath(@__DIR__, "assets"), artifact_dir; force = true)
+end
+
+archive_filename = "assets-$version.tar.gz"
+artifact_toml = joinpath(@__DIR__, "Artifacts.toml")
+download_hash = archive_artifact(product_hash, joinpath(build_path, archive_filename))
+
+bind_artifact!(
+    artifact_toml,
+    "assets",
+    product_hash,
+    force = true,
+    download_info = Tuple[
+        (
+            "$host/assets-$(escapeuri(string(version)))/$archive_filename",
+            download_hash,
+        ),
+    ],
+)

--- a/src/AbstractPlotting.jl
+++ b/src/AbstractPlotting.jl
@@ -1,5 +1,6 @@
 module AbstractPlotting
 
+using Artifacts
 using Random
 using FFMPEG # get FFMPEG on any system!
 using Observables, GeometryBasics, IntervalSets, PlotUtils
@@ -242,7 +243,7 @@ export cgrad, available_gradients, showgradients
 
 export Pattern
 
-assetpath(files...) = normpath(joinpath(@__DIR__, "..", "assets", files...))
+assetpath(files...) = normpath(joinpath(artifact"assets", files...))
 
 export assetpath
 # default icon for Makie

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -915,7 +915,7 @@ function convert_attribute(x::Union{Symbol, String}, k::key"font")
             end
         end
 
-        fontpath = joinpath(@__DIR__, "..", "assets", "fonts")
+        fontpath = assetpath("fonts")
         font = FreeTypeAbstraction.findfont(str; additional_fonts=fontpath)
         if font === nothing
             @warn("Could not find font $str, using Dejavu Sans")


### PR DESCRIPTION
Fixes https://github.com/JuliaPlots/Makie.jl/issues/949

Makes `AbstractPlotting` more amenable to inclusion in a relocated system image where the original source directories may not exist anymore.

Artifact creation is currently a manual process in this PR. Is the assets directory likely to change regularly enough that finding a way to automate the artifact creation process would be worth the extra effort, or is a manual step sufficient here?

CI _should_ fail on this pretty early since the referenced artifact URL does not exist. That'll need a maintainer to upload the built artifact first. Locally `test` seemed to work fine.