### PR TITLE
fix julia 1.5 failure

### DIFF
--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -362,7 +362,7 @@ function text_quads(positions, string::String, font, textsize)
         push!(scales, widths(glyph_bb))
         push!(offsets, minimum(glyph_bb))
     end
-    return positions, offsets, uv, scales
+    return convert(Vector{Point3f0}, positions), offsets, uv, scales
 end
 
 
@@ -386,7 +386,7 @@ function text_quads(allpos::Vector, strings::Vector, font, textsize)
             push!(offsets, minimum(glyph_bb))
         end
     end
-    return megapos, offsets, uv, scales
+    return convert(Vector{Point3f0}, megapos), offsets, uv, scales
 end
 
 


### PR DESCRIPTION
I'm not sure if `convert` is the right way to go about this, but this should fix https://github.com/JuliaPlots/Makie.jl/issues/948#event-4748713804. At least `scatter(rand(2))` works for me on 1.5 with this 